### PR TITLE
Add password recovery completion execution evidence

### DIFF
--- a/src/LagoVista.UserAdmin/Authentication/AuthenticationFlowService.cs
+++ b/src/LagoVista.UserAdmin/Authentication/AuthenticationFlowService.cs
@@ -13,11 +13,13 @@ namespace LagoVista.UserAdmin.Authentication
     {
         private readonly IPasswordLoginFlowHandler _passwordLoginHandler;
         private readonly IAuthenticationFlowHandler<PasswordRecoveryRequestFlowRequest> _passwordRecoveryRequestHandler;
+        private readonly IAuthenticationFlowHandler<PasswordRecoveryCompletionFlowRequest> _passwordRecoveryCompletionHandler;
 
-        public AuthenticationFlowService(IPasswordLoginFlowHandler passwordLoginHandler, IAuthenticationFlowHandler<PasswordRecoveryRequestFlowRequest> passwordRecoveryRequestHandler)
+        public AuthenticationFlowService(IPasswordLoginFlowHandler passwordLoginHandler, IAuthenticationFlowHandler<PasswordRecoveryRequestFlowRequest> passwordRecoveryRequestHandler, IAuthenticationFlowHandler<PasswordRecoveryCompletionFlowRequest> passwordRecoveryCompletionHandler = null)
         {
             _passwordLoginHandler = passwordLoginHandler ?? throw new ArgumentNullException(nameof(passwordLoginHandler));
             _passwordRecoveryRequestHandler = passwordRecoveryRequestHandler ?? throw new ArgumentNullException(nameof(passwordRecoveryRequestHandler));
+            _passwordRecoveryCompletionHandler = passwordRecoveryCompletionHandler;
         }
 
         public Task<InvokeResult<AuthenticationResponse>> LoginWithPasswordAsync(AuthLoginRequest request)
@@ -29,6 +31,18 @@ namespace LagoVista.UserAdmin.Authentication
         {
             var result = await _passwordRecoveryRequestHandler.HandleAsync(new PasswordRecoveryRequestFlowRequest(request));
             if (result.TransitionKey != PasswordRecoveryRequestFlowHandler.TransitionKey)
+                throw new InvalidOperationException($"Authentication flow emitted unsupported transition [{result.TransitionKey}].");
+
+            return result.PublicResult;
+        }
+
+        public async Task<InvokeResult> CompletePasswordRecoveryAsync(ResetPassword request)
+        {
+            if (_passwordRecoveryCompletionHandler == null)
+                throw new InvalidOperationException("Password recovery completion flow handler is not configured.");
+
+            var result = await _passwordRecoveryCompletionHandler.HandleAsync(new PasswordRecoveryCompletionFlowRequest(request));
+            if (result.TransitionKey != PasswordRecoveryCompletionFlowHandler.TransitionKey)
                 throw new InvalidOperationException($"Authentication flow emitted unsupported transition [{result.TransitionKey}].");
 
             return result.PublicResult;

--- a/src/LagoVista.UserAdmin/Authentication/Flows/PasswordRecoveryCompletionFlowHandler.cs
+++ b/src/LagoVista.UserAdmin/Authentication/Flows/PasswordRecoveryCompletionFlowHandler.cs
@@ -1,0 +1,28 @@
+using LagoVista.Core.Interfaces;
+using LagoVista.UserAdmin.Interfaces.Managers;
+using System;
+using System.Threading.Tasks;
+
+namespace LagoVista.UserAdmin.Authentication.Flows
+{
+    [CriticalCoverage]
+    public class PasswordRecoveryCompletionFlowHandler : IAuthenticationFlowHandler<PasswordRecoveryCompletionFlowRequest>
+    {
+        public const string TransitionKey = "auth.transition.recovery.complete";
+
+        private readonly IPasswordManager _passwordManager;
+
+        public PasswordRecoveryCompletionFlowHandler(IPasswordManager passwordManager)
+        {
+            _passwordManager = passwordManager ?? throw new ArgumentNullException(nameof(passwordManager));
+        }
+
+        public async Task<AuthenticationFlowResult> HandleAsync(PasswordRecoveryCompletionFlowRequest request)
+        {
+            if (request == null) throw new ArgumentNullException(nameof(request));
+
+            var result = await _passwordManager.ResetPasswordAsync(request.Request);
+            return new AuthenticationFlowResult(TransitionKey, result);
+        }
+    }
+}

--- a/src/LagoVista.UserAdmin/Authentication/Flows/PasswordRecoveryCompletionFlowRequest.cs
+++ b/src/LagoVista.UserAdmin/Authentication/Flows/PasswordRecoveryCompletionFlowRequest.cs
@@ -1,0 +1,15 @@
+using LagoVista.UserAdmin.Models.DTOs;
+using System;
+
+namespace LagoVista.UserAdmin.Authentication.Flows
+{
+    public class PasswordRecoveryCompletionFlowRequest
+    {
+        public PasswordRecoveryCompletionFlowRequest(ResetPassword request)
+        {
+            Request = request ?? throw new ArgumentNullException(nameof(request));
+        }
+
+        public ResetPassword Request { get; }
+    }
+}

--- a/src/LagoVista.UserAdmin/Authentication/IAuthenticationFlowService.cs
+++ b/src/LagoVista.UserAdmin/Authentication/IAuthenticationFlowService.cs
@@ -9,5 +9,6 @@ namespace LagoVista.UserAdmin.Authentication
     {
         Task<InvokeResult<AuthenticationResponse>> LoginWithPasswordAsync(AuthLoginRequest request);
         Task<InvokeResult> RequestPasswordRecoveryAsync(SendResetPasswordLink request);
+        Task<InvokeResult> CompletePasswordRecoveryAsync(ResetPassword request);
     }
 }

--- a/src/LagoVista.UserAdmin/Startup.cs
+++ b/src/LagoVista.UserAdmin/Startup.cs
@@ -46,6 +46,7 @@ namespace LagoVista.UserAdmin
             services.AddScoped<IFunctionMapManager, FunctionMapManager>();
             services.AddScoped<IPasswordLoginFlowHandler, PasswordLoginFlowHandler>();
             services.AddScoped<IAuthenticationFlowHandler<PasswordRecoveryRequestFlowRequest>, PasswordRecoveryRequestFlowHandler>();
+            services.AddScoped<IAuthenticationFlowHandler<PasswordRecoveryCompletionFlowRequest>, PasswordRecoveryCompletionFlowHandler>();
             services.AddScoped<IAuthenticationFlowService, AuthenticationFlowService>();
 
             Services.Startup.ConfigureServices(services, configuration);

--- a/tests/LagoVista.UserAdmin.Auth.Tests/PasswordRecoveryCompletionFlowIntegrationTests.cs
+++ b/tests/LagoVista.UserAdmin.Auth.Tests/PasswordRecoveryCompletionFlowIntegrationTests.cs
@@ -1,0 +1,116 @@
+using LagoVista.Core.Interfaces;
+using LagoVista.Core.Models;
+using LagoVista.Core.Validation;
+using LagoVista.IoT.Logging.Loggers;
+using LagoVista.UserAdmin.Authentication;
+using LagoVista.UserAdmin.Authentication.Flows;
+using LagoVista.UserAdmin.Interfaces.Managers;
+using LagoVista.UserAdmin.Managers;
+using LagoVista.UserAdmin.Models.Auth;
+using LagoVista.UserAdmin.Models.DTOs;
+using LagoVista.UserAdmin.Models.Security;
+using LagoVista.UserAdmin.Models.Users;
+using Moq;
+using NUnit.Framework;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace LagoVista.UserAdmin.Auth.Tests
+{
+    [TestFixture]
+    public class PasswordRecoveryCompletionFlowIntegrationTests
+    {
+        private const string RecoveryCompletionEvidence = "auth|auth.test-binding.recovery.complete|auth.flow.recovery.complete|auth.transition.recovery.complete";
+        private const string SuccessfulCompletionEvents = "PasswordRecoveryCompleted";
+
+        [Test]
+        [Property("AptixEvidence", RecoveryCompletionEvidence)]
+        [Property("AptixAuthEvents", SuccessfulCompletionEvents)]
+        public async Task SuccessfulReset_Should_CompleteRecovery_And_RecordMilestone()
+        {
+            var harness = CreateHarness();
+            var user = new AppUser("user@example.com", "test") { UserName = "user@example.com", Email = "user@example.com" };
+            var request = CreateRequest();
+
+            harness.UserManager.Setup(manager => manager.FindByEmailAsync(request.Email)).ReturnsAsync(user);
+            harness.UserManager.Setup(manager => manager.ResetPasswordAsync(user, request.Token, request.NewPassword)).ReturnsAsync(InvokeResult.Success);
+
+            var result = await harness.FlowService.CompletePasswordRecoveryAsync(request);
+
+            Assert.That(result.Successful, Is.True);
+            Assert.That(harness.Log.Events.Select(evt => evt.Type), Is.EqualTo(new AuthLogTypes?[]
+            {
+                AuthLogTypes.PasswordRecoveryCompleted
+            }));
+        }
+
+        [Test]
+        [Property("AptixEvidence", RecoveryCompletionEvidence)]
+        public async Task FailedReset_Should_ReturnFailure_WithoutRecordingCompletion()
+        {
+            var harness = CreateHarness();
+            var user = new AppUser("user@example.com", "test") { UserName = "user@example.com", Email = "user@example.com" };
+            var request = CreateRequest();
+            var failedResult = InvokeResult.FromErrors(new ErrorMessage("Reset failed."));
+
+            harness.UserManager.Setup(manager => manager.FindByEmailAsync(request.Email)).ReturnsAsync(user);
+            harness.UserManager.Setup(manager => manager.ResetPasswordAsync(user, request.Token, request.NewPassword)).ReturnsAsync(failedResult);
+
+            var result = await harness.FlowService.CompletePasswordRecoveryAsync(request);
+
+            Assert.That(result.Successful, Is.False);
+            Assert.That(harness.Log.Events, Is.Empty);
+        }
+
+        private static ResetPassword CreateRequest()
+        {
+            return new ResetPassword
+            {
+                Email = "user@example.com",
+                Token = "reset-token",
+                NewPassword = "NewPassword123!"
+            };
+        }
+
+        private static PasswordRecoveryCompletionHarness CreateHarness()
+        {
+            var log = new RecordingAuthenticationLogManager();
+            var validators = new Mock<IAuthRequestValidators>(MockBehavior.Strict);
+            var userManager = new Mock<IUserManager>(MockBehavior.Strict);
+            var appConfig = new Mock<IAppConfig>(MockBehavior.Loose);
+
+            validators
+                .Setup(validator => validator.ValidateResetPasswordRequest(It.IsAny<ResetPassword>()))
+                .Returns(InvokeResult.Success);
+            appConfig.SetupGet(config => config.SystemOwnerOrg).Returns(EntityHeader.Create("system", "System"));
+
+            var manager = new PasswordManager(
+                validators.Object,
+                userManager.Object,
+                new Mock<IEmailSender>(MockBehavior.Loose).Object,
+                new Mock<IDependencyManager>(MockBehavior.Loose).Object,
+                new Mock<ISecurity>(MockBehavior.Loose).Object,
+                log,
+                new Mock<IAdminLogger>(MockBehavior.Loose).Object,
+                appConfig.Object);
+
+            var completionHandler = new PasswordRecoveryCompletionFlowHandler(manager);
+            var passwordLoginHandler = new Mock<IPasswordLoginFlowHandler>(MockBehavior.Strict);
+            var recoveryRequestHandler = new Mock<IAuthenticationFlowHandler<PasswordRecoveryRequestFlowRequest>>(MockBehavior.Strict);
+
+            return new PasswordRecoveryCompletionHarness
+            {
+                Log = log,
+                UserManager = userManager,
+                FlowService = new AuthenticationFlowService(passwordLoginHandler.Object, recoveryRequestHandler.Object, completionHandler)
+            };
+        }
+
+        private sealed class PasswordRecoveryCompletionHarness
+        {
+            public RecordingAuthenticationLogManager Log { get; set; }
+            public Mock<IUserManager> UserManager { get; set; }
+            public AuthenticationFlowService FlowService { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- route password recovery completion through `AuthenticationFlowService`
- add the canonical recovery-completion flow request and handler
- register the handler with DI
- add real-path integration evidence for successful and failed resets

## Evidence
- success records `PasswordRecoveryCompleted`
- failed reset proves the completion milestone is not emitted
- tests bind `auth.flow.recovery.complete` to `auth.transition.recovery.complete`

## Verification needed
Run `LagoVista.UserAdmin.Auth.Tests`, regenerate `.aptix/evidence/LagoVista.UserAdmin.Auth.Tests.json`, and confirm the recovery-completion transition turns green in Aptix.