### PR TITLE
Add OAuth client registration substrate

### DIFF
--- a/src/LagoVista.UserAdmin.Models/Auth/OAuthClientApplication.cs
+++ b/src/LagoVista.UserAdmin.Models/Auth/OAuthClientApplication.cs
@@ -11,28 +11,25 @@ namespace LagoVista.UserAdmin.Models.Auth
 {
     public enum OAuthClientTypes
     {
-        [EnumLabel(OAuthClientApplication.ClientType_Public, UserAdminResources.Names.OAuthClientApplication_ClientType_Public, typeof(UserAdminResources))]
+        [EnumLabel(OAuthClientApplication.ClientType_Public, OAuthClientResources.Names.OAuthClientApplication_ClientType_Public, typeof(OAuthClientResources))]
         Public,
-
-        [EnumLabel(OAuthClientApplication.ClientType_Confidential, UserAdminResources.Names.OAuthClientApplication_ClientType_Confidential, typeof(UserAdminResources))]
+        [EnumLabel(OAuthClientApplication.ClientType_Confidential, OAuthClientResources.Names.OAuthClientApplication_ClientType_Confidential, typeof(OAuthClientResources))]
         Confidential,
     }
 
     public enum OAuthClientStatuses
     {
-        [EnumLabel(OAuthClientApplication.Status_Active, UserAdminResources.Names.OAuthClientApplication_Status_Active, typeof(UserAdminResources))]
+        [EnumLabel(OAuthClientApplication.Status_Active, OAuthClientResources.Names.OAuthClientApplication_Status_Active, typeof(OAuthClientResources))]
         Active,
-
-        [EnumLabel(OAuthClientApplication.Status_Disabled, UserAdminResources.Names.OAuthClientApplication_Status_Disabled, typeof(UserAdminResources))]
+        [EnumLabel(OAuthClientApplication.Status_Disabled, OAuthClientResources.Names.OAuthClientApplication_Status_Disabled, typeof(OAuthClientResources))]
         Disabled,
-
-        [EnumLabel(OAuthClientApplication.Status_Revoked, UserAdminResources.Names.OAuthClientApplication_Status_Revoked, typeof(UserAdminResources))]
+        [EnumLabel(OAuthClientApplication.Status_Revoked, OAuthClientResources.Names.OAuthClientApplication_Status_Revoked, typeof(OAuthClientResources))]
         Revoked,
     }
 
-    [EntityDescription(
-        Domains.SecurityDomain, UserAdminResources.Names.OAuthClientApplication_Title, UserAdminResources.Names.OAuthClientApplication_Help,
-        UserAdminResources.Names.OAuthClientApplication_Description, EntityDescriptionAttribute.EntityTypes.OrganizationModel, typeof(UserAdminResources),
+    [EntityDescription(Domains.SecurityDomain, OAuthClientResources.Names.OAuthClientApplication_Title,
+        OAuthClientResources.Names.OAuthClientApplication_Help, OAuthClientResources.Names.OAuthClientApplication_Description,
+        EntityDescriptionAttribute.EntityTypes.OrganizationModel, typeof(OAuthClientResources),
         SaveUrl: "/api/oauth/client", GetListUrl: "/api/oauth/clients", GetUrl: "/api/oauth/client/{id}",
         DeleteUrl: "/api/oauth/client/{id}", FactoryUrl: "/api/oauth/client/factory",
         ListUIUrl: "/security/oauth-clients", EditUIUrl: "/security/oauth-client/{id}", CreateUIUrl: "/security/oauth-client/add",
@@ -41,11 +38,10 @@ namespace LagoVista.UserAdmin.Models.Auth
         IndexInclude: true, IndexTier: EntityDescriptionAttribute.IndexTiers.Primary, IndexPriority: 90,
         IndexTagsCsv: "securitydomain,oauth,clients,configuration")]
     public class OAuthClientApplication : UserAdminModelBase, IKeyedEntity, INamedEntity, IValidateable, IOwnedEntity,
-                                          IDescriptionEntity, IFormDescriptor, IFormConditionalFields, ISummaryFactory
+        IDescriptionEntity, IFormDescriptor, IFormConditionalFields, ISummaryFactory
     {
         public const string ClientType_Public = "public";
         public const string ClientType_Confidential = "confidential";
-
         public const string Status_Active = "active";
         public const string Status_Disabled = "disabled";
         public const string Status_Revoked = "revoked";
@@ -64,108 +60,98 @@ namespace LagoVista.UserAdmin.Models.Auth
             Icon = "icon-ae-key";
         }
 
-        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_ClientId,
-            HelpResource: UserAdminResources.Names.OAuthClientApplication_ClientId_Help,
-            FieldType: FieldTypes.Text, ResourceType: typeof(UserAdminResources), IsRequired: true, IsUserEditable: true)]
+        [FormField(LabelResource: OAuthClientResources.Names.OAuthClientApplication_ClientId,
+            HelpResource: OAuthClientResources.Names.OAuthClientApplication_ClientId_Help,
+            FieldType: FieldTypes.Text, ResourceType: typeof(OAuthClientResources), IsRequired: true, IsUserEditable: true)]
         public string ClientId { get; set; }
 
-        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_ClientType,
-            HelpResource: UserAdminResources.Names.OAuthClientApplication_ClientType_Help,
-            WaterMark: UserAdminResources.Names.OAuthClientApplication_ClientType_Select,
-            FieldType: FieldTypes.Picker, EnumType: typeof(OAuthClientTypes), ResourceType: typeof(UserAdminResources), IsRequired: true)]
+        [FormField(LabelResource: OAuthClientResources.Names.OAuthClientApplication_ClientType,
+            HelpResource: OAuthClientResources.Names.OAuthClientApplication_ClientType_Help,
+            WaterMark: OAuthClientResources.Names.OAuthClientApplication_ClientType_Select,
+            FieldType: FieldTypes.Picker, EnumType: typeof(OAuthClientTypes), ResourceType: typeof(OAuthClientResources), IsRequired: true)]
         public EntityHeader<OAuthClientTypes> ClientType { get; set; }
 
-        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_Status,
-            HelpResource: UserAdminResources.Names.OAuthClientApplication_Status_Help,
-            WaterMark: UserAdminResources.Names.OAuthClientApplication_Status_Select,
-            FieldType: FieldTypes.Picker, EnumType: typeof(OAuthClientStatuses), ResourceType: typeof(UserAdminResources), IsRequired: true)]
+        [FormField(LabelResource: OAuthClientResources.Names.OAuthClientApplication_Status,
+            HelpResource: OAuthClientResources.Names.OAuthClientApplication_Status_Help,
+            WaterMark: OAuthClientResources.Names.OAuthClientApplication_Status_Select,
+            FieldType: FieldTypes.Picker, EnumType: typeof(OAuthClientStatuses), ResourceType: typeof(OAuthClientResources), IsRequired: true)]
         public EntityHeader<OAuthClientStatuses> Status { get; set; }
 
-        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_ClientSecret,
-            HelpResource: UserAdminResources.Names.OAuthClientApplication_ClientSecret_Help,
+        [FormField(LabelResource: OAuthClientResources.Names.OAuthClientApplication_ClientSecret,
+            HelpResource: OAuthClientResources.Names.OAuthClientApplication_ClientSecret_Help,
             SecureIdFieldName: nameof(ClientSecretId), FieldType: FieldTypes.Secret,
-            ResourceType: typeof(UserAdminResources), IsRequired: false, IsUserEditable: true)]
+            ResourceType: typeof(OAuthClientResources), IsUserEditable: true)]
         public string ClientSecret { get; set; }
 
         public string ClientSecretId { get; set; }
 
-        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_RedirectUris,
-            HelpResource: UserAdminResources.Names.OAuthClientApplication_RedirectUris_Help,
+        [FormField(LabelResource: OAuthClientResources.Names.OAuthClientApplication_RedirectUris,
+            HelpResource: OAuthClientResources.Names.OAuthClientApplication_RedirectUris_Help,
             FieldType: FieldTypes.ChildListInline, FactoryUrl: "/api/oauth/client/value/factory",
-            ResourceType: typeof(UserAdminResources), IsRequired: true)]
+            ResourceType: typeof(OAuthClientResources), IsRequired: true)]
         public List<OAuthClientSettingValue> RedirectUris { get; set; }
 
-        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_PostLogoutRedirectUris,
-            HelpResource: UserAdminResources.Names.OAuthClientApplication_PostLogoutRedirectUris_Help,
+        [FormField(LabelResource: OAuthClientResources.Names.OAuthClientApplication_PostLogoutRedirectUris,
+            HelpResource: OAuthClientResources.Names.OAuthClientApplication_PostLogoutRedirectUris_Help,
             FieldType: FieldTypes.ChildListInline, FactoryUrl: "/api/oauth/client/value/factory",
-            ResourceType: typeof(UserAdminResources))]
+            ResourceType: typeof(OAuthClientResources))]
         public List<OAuthClientSettingValue> PostLogoutRedirectUris { get; set; }
 
-        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_AllowedGrantTypes,
-            HelpResource: UserAdminResources.Names.OAuthClientApplication_AllowedGrantTypes_Help,
+        [FormField(LabelResource: OAuthClientResources.Names.OAuthClientApplication_AllowedGrantTypes,
+            HelpResource: OAuthClientResources.Names.OAuthClientApplication_AllowedGrantTypes_Help,
             FieldType: FieldTypes.ChildListInline, FactoryUrl: "/api/oauth/client/value/factory",
-            ResourceType: typeof(UserAdminResources), IsRequired: true)]
+            ResourceType: typeof(OAuthClientResources), IsRequired: true)]
         public List<OAuthClientSettingValue> AllowedGrantTypes { get; set; }
 
-        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_AllowedScopes,
-            HelpResource: UserAdminResources.Names.OAuthClientApplication_AllowedScopes_Help,
+        [FormField(LabelResource: OAuthClientResources.Names.OAuthClientApplication_AllowedScopes,
+            HelpResource: OAuthClientResources.Names.OAuthClientApplication_AllowedScopes_Help,
             FieldType: FieldTypes.ChildListInline, FactoryUrl: "/api/oauth/client/value/factory",
-            ResourceType: typeof(UserAdminResources), IsRequired: true)]
+            ResourceType: typeof(OAuthClientResources), IsRequired: true)]
         public List<OAuthClientSettingValue> AllowedScopes { get; set; }
 
-        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_AllowedResources,
-            HelpResource: UserAdminResources.Names.OAuthClientApplication_AllowedResources_Help,
+        [FormField(LabelResource: OAuthClientResources.Names.OAuthClientApplication_AllowedResources,
+            HelpResource: OAuthClientResources.Names.OAuthClientApplication_AllowedResources_Help,
             FieldType: FieldTypes.ChildListInline, FactoryUrl: "/api/oauth/client/value/factory",
-            ResourceType: typeof(UserAdminResources), IsRequired: true)]
+            ResourceType: typeof(OAuthClientResources), IsRequired: true)]
         public List<OAuthClientSettingValue> AllowedResources { get; set; }
 
-        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_RequirePkce,
-            HelpResource: UserAdminResources.Names.OAuthClientApplication_RequirePkce_Help,
-            FieldType: FieldTypes.CheckBox, ResourceType: typeof(UserAdminResources))]
+        [FormField(LabelResource: OAuthClientResources.Names.OAuthClientApplication_RequirePkce,
+            HelpResource: OAuthClientResources.Names.OAuthClientApplication_RequirePkce_Help,
+            FieldType: FieldTypes.CheckBox, ResourceType: typeof(OAuthClientResources))]
         public bool RequirePkce { get; set; }
 
-        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_RequireConsent,
-            HelpResource: UserAdminResources.Names.OAuthClientApplication_RequireConsent_Help,
-            FieldType: FieldTypes.CheckBox, ResourceType: typeof(UserAdminResources))]
+        [FormField(LabelResource: OAuthClientResources.Names.OAuthClientApplication_RequireConsent,
+            HelpResource: OAuthClientResources.Names.OAuthClientApplication_RequireConsent_Help,
+            FieldType: FieldTypes.CheckBox, ResourceType: typeof(OAuthClientResources))]
         public bool RequireConsent { get; set; }
 
-        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_AccessTokenLifetimeMinutes,
-            HelpResource: UserAdminResources.Names.OAuthClientApplication_AccessTokenLifetimeMinutes_Help,
-            FieldType: FieldTypes.Integer, ResourceType: typeof(UserAdminResources))]
+        [FormField(LabelResource: OAuthClientResources.Names.OAuthClientApplication_AccessTokenLifetimeMinutes,
+            HelpResource: OAuthClientResources.Names.OAuthClientApplication_AccessTokenLifetimeMinutes_Help,
+            FieldType: FieldTypes.Integer, ResourceType: typeof(OAuthClientResources))]
         public int? AccessTokenLifetimeMinutes { get; set; }
 
-        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_RefreshTokenLifetimeDays,
-            HelpResource: UserAdminResources.Names.OAuthClientApplication_RefreshTokenLifetimeDays_Help,
-            FieldType: FieldTypes.Integer, ResourceType: typeof(UserAdminResources))]
+        [FormField(LabelResource: OAuthClientResources.Names.OAuthClientApplication_RefreshTokenLifetimeDays,
+            HelpResource: OAuthClientResources.Names.OAuthClientApplication_RefreshTokenLifetimeDays_Help,
+            FieldType: FieldTypes.Integer, ResourceType: typeof(OAuthClientResources))]
         public int? RefreshTokenLifetimeDays { get; set; }
 
-        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_LogoUrl,
-            FieldType: FieldTypes.Text, ResourceType: typeof(UserAdminResources))]
+        [FormField(LabelResource: OAuthClientResources.Names.OAuthClientApplication_LogoUrl, FieldType: FieldTypes.Text, ResourceType: typeof(OAuthClientResources))]
         public string LogoUrl { get; set; }
 
-        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_PrivacyPolicyUrl,
-            FieldType: FieldTypes.Text, ResourceType: typeof(UserAdminResources))]
+        [FormField(LabelResource: OAuthClientResources.Names.OAuthClientApplication_PrivacyPolicyUrl, FieldType: FieldTypes.Text, ResourceType: typeof(OAuthClientResources))]
         public string PrivacyPolicyUrl { get; set; }
 
-        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_TermsOfServiceUrl,
-            FieldType: FieldTypes.Text, ResourceType: typeof(UserAdminResources))]
+        [FormField(LabelResource: OAuthClientResources.Names.OAuthClientApplication_TermsOfServiceUrl, FieldType: FieldTypes.Text, ResourceType: typeof(OAuthClientResources))]
         public string TermsOfServiceUrl { get; set; }
 
         [CustomValidator]
         public void Validate(ValidationResult result, Actions action)
         {
-            if (EntityHeader.IsNullOrEmpty(ClientType))
-                result.AddUserError("OAuth client type is required.");
-
-            if (EntityHeader.IsNullOrEmpty(Status))
-                result.AddUserError("OAuth client status is required.");
-
-            if (ClientType?.Id == ClientType_Public && !RequirePkce)
-                result.AddUserError("Public OAuth clients must require PKCE.");
-
+            if (EntityHeader.IsNullOrEmpty(ClientType)) result.AddUserError("OAuth client type is required.");
+            if (EntityHeader.IsNullOrEmpty(Status)) result.AddUserError("OAuth client status is required.");
+            if (ClientType?.Id == ClientType_Public && !RequirePkce) result.AddUserError("Public OAuth clients must require PKCE.");
             if (ClientType?.Id == ClientType_Public && (!String.IsNullOrEmpty(ClientSecret) || !String.IsNullOrEmpty(ClientSecretId)))
                 result.AddUserError("Public OAuth clients cannot have a client secret.");
-
             if (Status?.Id == Status_Active && ClientType?.Id == ClientType_Confidential && String.IsNullOrEmpty(ClientSecret) && String.IsNullOrEmpty(ClientSecretId))
                 result.AddUserError("An active confidential OAuth client requires a client secret.");
 
@@ -183,16 +169,12 @@ namespace LagoVista.UserAdmin.Models.Auth
                 return;
             }
 
-            if (values == null)
-                return;
-
+            if (values == null) return;
             var uniqueValues = new HashSet<string>(StringComparer.Ordinal);
             foreach (var value in values)
             {
-                if (value == null || String.IsNullOrWhiteSpace(value.Value))
-                    result.AddUserError($"{fieldName} contains an empty value.");
-                else if (!uniqueValues.Add(value.Value))
-                    result.AddUserError($"{fieldName} contains the duplicate value [{value.Value}].");
+                if (value == null || String.IsNullOrWhiteSpace(value.Value)) result.AddUserError($"{fieldName} contains an empty value.");
+                else if (!uniqueValues.Add(value.Value)) result.AddUserError($"{fieldName} contains the duplicate value [{value.Value}].");
             }
         }
 
@@ -200,32 +182,16 @@ namespace LagoVista.UserAdmin.Models.Auth
         {
             return new OAuthClientApplicationSummary
             {
-                Id = Id,
-                Key = Key,
-                Name = Name,
-                Description = Description,
-                Icon = Icon,
-                IsPublic = IsPublic,
-                CategoryId = Category?.Id,
-                Category = Category?.Text,
-                CategoryKey = Category?.Key,
-                ClientId = ClientId,
-                ClientType = ClientType?.Text,
-                ClientTypeId = ClientType?.Id,
-                Status = Status?.Text,
-                StatusId = Status?.Id,
-                RequirePkce = RequirePkce,
-                RequireConsent = RequireConsent,
-                HasClientSecret = !String.IsNullOrEmpty(ClientSecretId),
-                RedirectUriCount = RedirectUris?.Count ?? 0,
+                Id = Id, Key = Key, Name = Name, Description = Description, Icon = Icon, IsPublic = IsPublic,
+                CategoryId = Category?.Id, Category = Category?.Text, CategoryKey = Category?.Key,
+                ClientId = ClientId, ClientType = ClientType?.Text, ClientTypeId = ClientType?.Id,
+                Status = Status?.Text, StatusId = Status?.Id, RequirePkce = RequirePkce, RequireConsent = RequireConsent,
+                HasClientSecret = !String.IsNullOrEmpty(ClientSecretId), RedirectUriCount = RedirectUris?.Count ?? 0,
                 ScopeCount = AllowedScopes?.Count ?? 0,
             };
         }
 
-        ISummaryData ISummaryFactory.CreateSummary()
-        {
-            return CreateSummary();
-        }
+        ISummaryData ISummaryFactory.CreateSummary() => CreateSummary();
 
         public List<string> GetFormFields()
         {
@@ -246,20 +212,15 @@ namespace LagoVista.UserAdmin.Models.Auth
                 ConditionalFields = new List<string> { nameof(ClientSecret) },
                 Conditionals = new List<FormConditional>
                 {
-                    new FormConditional
-                    {
-                        Field = nameof(ClientType),
-                        Value = ClientType_Confidential,
-                        VisibleFields = new List<string> { nameof(ClientSecret) },
-                    }
+                    new FormConditional { Field = nameof(ClientType), Value = ClientType_Confidential, VisibleFields = new List<string> { nameof(ClientSecret) } }
                 }
             };
         }
     }
 
-    [EntityDescription(Domains.SecurityDomain, UserAdminResources.Names.OAuthClientApplications_Title,
-        UserAdminResources.Names.OAuthClientApplication_Help, UserAdminResources.Names.OAuthClientApplication_Description,
-        EntityDescriptionAttribute.EntityTypes.Summary, typeof(UserAdminResources),
+    [EntityDescription(Domains.SecurityDomain, OAuthClientResources.Names.OAuthClientApplications_Title,
+        OAuthClientResources.Names.OAuthClientApplication_Help, OAuthClientResources.Names.OAuthClientApplication_Description,
+        EntityDescriptionAttribute.EntityTypes.Summary, typeof(OAuthClientResources),
         ListUIUrl: "/security/oauth-clients", EditUIUrl: "/security/oauth-client/{id}", CreateUIUrl: "/security/oauth-client/add",
         SaveUrl: "/api/oauth/client", GetListUrl: "/api/oauth/clients", GetUrl: "/api/oauth/client/{id}",
         DeleteUrl: "/api/oauth/client/{id}", FactoryUrl: "/api/oauth/client/factory", Icon: "icon-ae-key")]
@@ -277,27 +238,23 @@ namespace LagoVista.UserAdmin.Models.Auth
         public int ScopeCount { get; set; }
     }
 
-    [EntityDescription(Domains.SecurityDomain, UserAdminResources.Names.OAuthClientSettingValue_Title,
-        UserAdminResources.Names.OAuthClientSettingValue_Help, UserAdminResources.Names.OAuthClientSettingValue_Help,
-        EntityDescriptionAttribute.EntityTypes.Dto, typeof(UserAdminResources), FactoryUrl: "/api/oauth/client/value/factory")]
+    [EntityDescription(Domains.SecurityDomain, OAuthClientResources.Names.OAuthClientSettingValue_Title,
+        OAuthClientResources.Names.OAuthClientSettingValue_Help, OAuthClientResources.Names.OAuthClientSettingValue_Help,
+        EntityDescriptionAttribute.EntityTypes.Dto, typeof(OAuthClientResources), FactoryUrl: "/api/oauth/client/value/factory")]
     public class OAuthClientSettingValue : IFormDescriptor, IValidateable
     {
         public string Id { get; set; } = Guid.NewGuid().ToId();
 
-        [FormField(LabelResource: UserAdminResources.Names.OAuthClientSettingValue_Value,
-            FieldType: FieldTypes.Text, ResourceType: typeof(UserAdminResources), IsRequired: true, IsUserEditable: true)]
+        [FormField(LabelResource: OAuthClientResources.Names.OAuthClientSettingValue_Value,
+            FieldType: FieldTypes.Text, ResourceType: typeof(OAuthClientResources), IsRequired: true, IsUserEditable: true)]
         public string Value { get; set; }
 
         [CustomValidator]
         public void Validate(ValidationResult result, Actions action)
         {
-            if (String.IsNullOrWhiteSpace(Value))
-                result.AddUserError("Value is required.");
+            if (String.IsNullOrWhiteSpace(Value)) result.AddUserError("Value is required.");
         }
 
-        public List<string> GetFormFields()
-        {
-            return new List<string> { nameof(Value) };
-        }
+        public List<string> GetFormFields() => new List<string> { nameof(Value) };
     }
 }

--- a/src/LagoVista.UserAdmin.Models/Auth/OAuthClientApplication.cs
+++ b/src/LagoVista.UserAdmin.Models/Auth/OAuthClientApplication.cs
@@ -1,0 +1,303 @@
+using LagoVista.Core.Attributes;
+using LagoVista.Core.Interfaces;
+using LagoVista.Core.Models;
+using LagoVista.Core.Models.UIMetaData;
+using LagoVista.Core.Validation;
+using LagoVista.UserAdmin.Models.Resources;
+using System;
+using System.Collections.Generic;
+
+namespace LagoVista.UserAdmin.Models.Auth
+{
+    public enum OAuthClientTypes
+    {
+        [EnumLabel(OAuthClientApplication.ClientType_Public, UserAdminResources.Names.OAuthClientApplication_ClientType_Public, typeof(UserAdminResources))]
+        Public,
+
+        [EnumLabel(OAuthClientApplication.ClientType_Confidential, UserAdminResources.Names.OAuthClientApplication_ClientType_Confidential, typeof(UserAdminResources))]
+        Confidential,
+    }
+
+    public enum OAuthClientStatuses
+    {
+        [EnumLabel(OAuthClientApplication.Status_Active, UserAdminResources.Names.OAuthClientApplication_Status_Active, typeof(UserAdminResources))]
+        Active,
+
+        [EnumLabel(OAuthClientApplication.Status_Disabled, UserAdminResources.Names.OAuthClientApplication_Status_Disabled, typeof(UserAdminResources))]
+        Disabled,
+
+        [EnumLabel(OAuthClientApplication.Status_Revoked, UserAdminResources.Names.OAuthClientApplication_Status_Revoked, typeof(UserAdminResources))]
+        Revoked,
+    }
+
+    [EntityDescription(
+        Domains.SecurityDomain, UserAdminResources.Names.OAuthClientApplication_Title, UserAdminResources.Names.OAuthClientApplication_Help,
+        UserAdminResources.Names.OAuthClientApplication_Description, EntityDescriptionAttribute.EntityTypes.OrganizationModel, typeof(UserAdminResources),
+        SaveUrl: "/api/oauth/client", GetListUrl: "/api/oauth/clients", GetUrl: "/api/oauth/client/{id}",
+        DeleteUrl: "/api/oauth/client/{id}", FactoryUrl: "/api/oauth/client/factory",
+        ListUIUrl: "/security/oauth-clients", EditUIUrl: "/security/oauth-client/{id}", CreateUIUrl: "/security/oauth-client/add",
+        Icon: "icon-ae-key", ClusterKey: "security", ModelType: EntityDescriptionAttribute.ModelTypes.Configuration,
+        Lifecycle: EntityDescriptionAttribute.Lifecycles.DesignTime, Sensitivity: EntityDescriptionAttribute.Sensitivities.Confidential,
+        IndexInclude: true, IndexTier: EntityDescriptionAttribute.IndexTiers.Primary, IndexPriority: 90,
+        IndexTagsCsv: "securitydomain,oauth,clients,configuration")]
+    public class OAuthClientApplication : UserAdminModelBase, IKeyedEntity, INamedEntity, IValidateable, IOwnedEntity,
+                                          IDescriptionEntity, IFormDescriptor, IFormConditionalFields, ISummaryFactory
+    {
+        public const string ClientType_Public = "public";
+        public const string ClientType_Confidential = "confidential";
+
+        public const string Status_Active = "active";
+        public const string Status_Disabled = "disabled";
+        public const string Status_Revoked = "revoked";
+
+        public OAuthClientApplication()
+        {
+            ClientType = EntityHeader<OAuthClientTypes>.Create(OAuthClientTypes.Public);
+            Status = EntityHeader<OAuthClientStatuses>.Create(OAuthClientStatuses.Disabled);
+            RedirectUris = new List<OAuthClientSettingValue>();
+            PostLogoutRedirectUris = new List<OAuthClientSettingValue>();
+            AllowedGrantTypes = new List<OAuthClientSettingValue>();
+            AllowedScopes = new List<OAuthClientSettingValue>();
+            AllowedResources = new List<OAuthClientSettingValue>();
+            RequirePkce = true;
+            RequireConsent = true;
+            Icon = "icon-ae-key";
+        }
+
+        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_ClientId,
+            HelpResource: UserAdminResources.Names.OAuthClientApplication_ClientId_Help,
+            FieldType: FieldTypes.Text, ResourceType: typeof(UserAdminResources), IsRequired: true, IsUserEditable: true)]
+        public string ClientId { get; set; }
+
+        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_ClientType,
+            HelpResource: UserAdminResources.Names.OAuthClientApplication_ClientType_Help,
+            WaterMark: UserAdminResources.Names.OAuthClientApplication_ClientType_Select,
+            FieldType: FieldTypes.Picker, EnumType: typeof(OAuthClientTypes), ResourceType: typeof(UserAdminResources), IsRequired: true)]
+        public EntityHeader<OAuthClientTypes> ClientType { get; set; }
+
+        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_Status,
+            HelpResource: UserAdminResources.Names.OAuthClientApplication_Status_Help,
+            WaterMark: UserAdminResources.Names.OAuthClientApplication_Status_Select,
+            FieldType: FieldTypes.Picker, EnumType: typeof(OAuthClientStatuses), ResourceType: typeof(UserAdminResources), IsRequired: true)]
+        public EntityHeader<OAuthClientStatuses> Status { get; set; }
+
+        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_ClientSecret,
+            HelpResource: UserAdminResources.Names.OAuthClientApplication_ClientSecret_Help,
+            SecureIdFieldName: nameof(ClientSecretId), FieldType: FieldTypes.Secret,
+            ResourceType: typeof(UserAdminResources), IsRequired: false, IsUserEditable: true)]
+        public string ClientSecret { get; set; }
+
+        public string ClientSecretId { get; set; }
+
+        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_RedirectUris,
+            HelpResource: UserAdminResources.Names.OAuthClientApplication_RedirectUris_Help,
+            FieldType: FieldTypes.ChildListInline, FactoryUrl: "/api/oauth/client/value/factory",
+            ResourceType: typeof(UserAdminResources), IsRequired: true)]
+        public List<OAuthClientSettingValue> RedirectUris { get; set; }
+
+        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_PostLogoutRedirectUris,
+            HelpResource: UserAdminResources.Names.OAuthClientApplication_PostLogoutRedirectUris_Help,
+            FieldType: FieldTypes.ChildListInline, FactoryUrl: "/api/oauth/client/value/factory",
+            ResourceType: typeof(UserAdminResources))]
+        public List<OAuthClientSettingValue> PostLogoutRedirectUris { get; set; }
+
+        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_AllowedGrantTypes,
+            HelpResource: UserAdminResources.Names.OAuthClientApplication_AllowedGrantTypes_Help,
+            FieldType: FieldTypes.ChildListInline, FactoryUrl: "/api/oauth/client/value/factory",
+            ResourceType: typeof(UserAdminResources), IsRequired: true)]
+        public List<OAuthClientSettingValue> AllowedGrantTypes { get; set; }
+
+        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_AllowedScopes,
+            HelpResource: UserAdminResources.Names.OAuthClientApplication_AllowedScopes_Help,
+            FieldType: FieldTypes.ChildListInline, FactoryUrl: "/api/oauth/client/value/factory",
+            ResourceType: typeof(UserAdminResources), IsRequired: true)]
+        public List<OAuthClientSettingValue> AllowedScopes { get; set; }
+
+        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_AllowedResources,
+            HelpResource: UserAdminResources.Names.OAuthClientApplication_AllowedResources_Help,
+            FieldType: FieldTypes.ChildListInline, FactoryUrl: "/api/oauth/client/value/factory",
+            ResourceType: typeof(UserAdminResources), IsRequired: true)]
+        public List<OAuthClientSettingValue> AllowedResources { get; set; }
+
+        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_RequirePkce,
+            HelpResource: UserAdminResources.Names.OAuthClientApplication_RequirePkce_Help,
+            FieldType: FieldTypes.CheckBox, ResourceType: typeof(UserAdminResources))]
+        public bool RequirePkce { get; set; }
+
+        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_RequireConsent,
+            HelpResource: UserAdminResources.Names.OAuthClientApplication_RequireConsent_Help,
+            FieldType: FieldTypes.CheckBox, ResourceType: typeof(UserAdminResources))]
+        public bool RequireConsent { get; set; }
+
+        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_AccessTokenLifetimeMinutes,
+            HelpResource: UserAdminResources.Names.OAuthClientApplication_AccessTokenLifetimeMinutes_Help,
+            FieldType: FieldTypes.Integer, ResourceType: typeof(UserAdminResources))]
+        public int? AccessTokenLifetimeMinutes { get; set; }
+
+        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_RefreshTokenLifetimeDays,
+            HelpResource: UserAdminResources.Names.OAuthClientApplication_RefreshTokenLifetimeDays_Help,
+            FieldType: FieldTypes.Integer, ResourceType: typeof(UserAdminResources))]
+        public int? RefreshTokenLifetimeDays { get; set; }
+
+        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_LogoUrl,
+            FieldType: FieldTypes.Text, ResourceType: typeof(UserAdminResources))]
+        public string LogoUrl { get; set; }
+
+        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_PrivacyPolicyUrl,
+            FieldType: FieldTypes.Text, ResourceType: typeof(UserAdminResources))]
+        public string PrivacyPolicyUrl { get; set; }
+
+        [FormField(LabelResource: UserAdminResources.Names.OAuthClientApplication_TermsOfServiceUrl,
+            FieldType: FieldTypes.Text, ResourceType: typeof(UserAdminResources))]
+        public string TermsOfServiceUrl { get; set; }
+
+        [CustomValidator]
+        public void Validate(ValidationResult result, Actions action)
+        {
+            if (EntityHeader.IsNullOrEmpty(ClientType))
+                result.AddUserError("OAuth client type is required.");
+
+            if (EntityHeader.IsNullOrEmpty(Status))
+                result.AddUserError("OAuth client status is required.");
+
+            if (ClientType?.Id == ClientType_Public && !RequirePkce)
+                result.AddUserError("Public OAuth clients must require PKCE.");
+
+            if (ClientType?.Id == ClientType_Public && (!String.IsNullOrEmpty(ClientSecret) || !String.IsNullOrEmpty(ClientSecretId)))
+                result.AddUserError("Public OAuth clients cannot have a client secret.");
+
+            if (Status?.Id == Status_Active && ClientType?.Id == ClientType_Confidential && String.IsNullOrEmpty(ClientSecret) && String.IsNullOrEmpty(ClientSecretId))
+                result.AddUserError("An active confidential OAuth client requires a client secret.");
+
+            ValidateValues(result, RedirectUris, nameof(RedirectUris), true);
+            ValidateValues(result, AllowedGrantTypes, nameof(AllowedGrantTypes), true);
+            ValidateValues(result, AllowedScopes, nameof(AllowedScopes), true);
+            ValidateValues(result, AllowedResources, nameof(AllowedResources), true);
+        }
+
+        private static void ValidateValues(ValidationResult result, List<OAuthClientSettingValue> values, string fieldName, bool required)
+        {
+            if (required && (values == null || values.Count == 0))
+            {
+                result.AddUserError($"{fieldName} requires at least one value.");
+                return;
+            }
+
+            if (values == null)
+                return;
+
+            var uniqueValues = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var value in values)
+            {
+                if (value == null || String.IsNullOrWhiteSpace(value.Value))
+                    result.AddUserError($"{fieldName} contains an empty value.");
+                else if (!uniqueValues.Add(value.Value))
+                    result.AddUserError($"{fieldName} contains the duplicate value [{value.Value}].");
+            }
+        }
+
+        public OAuthClientApplicationSummary CreateSummary()
+        {
+            return new OAuthClientApplicationSummary
+            {
+                Id = Id,
+                Key = Key,
+                Name = Name,
+                Description = Description,
+                Icon = Icon,
+                IsPublic = IsPublic,
+                CategoryId = Category?.Id,
+                Category = Category?.Text,
+                CategoryKey = Category?.Key,
+                ClientId = ClientId,
+                ClientType = ClientType?.Text,
+                ClientTypeId = ClientType?.Id,
+                Status = Status?.Text,
+                StatusId = Status?.Id,
+                RequirePkce = RequirePkce,
+                RequireConsent = RequireConsent,
+                HasClientSecret = !String.IsNullOrEmpty(ClientSecretId),
+                RedirectUriCount = RedirectUris?.Count ?? 0,
+                ScopeCount = AllowedScopes?.Count ?? 0,
+            };
+        }
+
+        ISummaryData ISummaryFactory.CreateSummary()
+        {
+            return CreateSummary();
+        }
+
+        public List<string> GetFormFields()
+        {
+            return new List<string>
+            {
+                nameof(Name), nameof(Key), nameof(Description), nameof(ClientId), nameof(ClientType), nameof(Status),
+                nameof(ClientSecret), nameof(RedirectUris), nameof(PostLogoutRedirectUris), nameof(AllowedGrantTypes),
+                nameof(AllowedScopes), nameof(AllowedResources), nameof(RequirePkce), nameof(RequireConsent),
+                nameof(AccessTokenLifetimeMinutes), nameof(RefreshTokenLifetimeDays), nameof(LogoUrl),
+                nameof(PrivacyPolicyUrl), nameof(TermsOfServiceUrl),
+            };
+        }
+
+        public FormConditionals GetConditionalFields()
+        {
+            return new FormConditionals
+            {
+                ConditionalFields = new List<string> { nameof(ClientSecret) },
+                Conditionals = new List<FormConditional>
+                {
+                    new FormConditional
+                    {
+                        Field = nameof(ClientType),
+                        Value = ClientType_Confidential,
+                        VisibleFields = new List<string> { nameof(ClientSecret) },
+                    }
+                }
+            };
+        }
+    }
+
+    [EntityDescription(Domains.SecurityDomain, UserAdminResources.Names.OAuthClientApplications_Title,
+        UserAdminResources.Names.OAuthClientApplication_Help, UserAdminResources.Names.OAuthClientApplication_Description,
+        EntityDescriptionAttribute.EntityTypes.Summary, typeof(UserAdminResources),
+        ListUIUrl: "/security/oauth-clients", EditUIUrl: "/security/oauth-client/{id}", CreateUIUrl: "/security/oauth-client/add",
+        SaveUrl: "/api/oauth/client", GetListUrl: "/api/oauth/clients", GetUrl: "/api/oauth/client/{id}",
+        DeleteUrl: "/api/oauth/client/{id}", FactoryUrl: "/api/oauth/client/factory", Icon: "icon-ae-key")]
+    public class OAuthClientApplicationSummary : SummaryData
+    {
+        public string ClientId { get; set; }
+        public string ClientType { get; set; }
+        public string ClientTypeId { get; set; }
+        public string Status { get; set; }
+        public string StatusId { get; set; }
+        public bool RequirePkce { get; set; }
+        public bool RequireConsent { get; set; }
+        public bool HasClientSecret { get; set; }
+        public int RedirectUriCount { get; set; }
+        public int ScopeCount { get; set; }
+    }
+
+    [EntityDescription(Domains.SecurityDomain, UserAdminResources.Names.OAuthClientSettingValue_Title,
+        UserAdminResources.Names.OAuthClientSettingValue_Help, UserAdminResources.Names.OAuthClientSettingValue_Help,
+        EntityDescriptionAttribute.EntityTypes.Dto, typeof(UserAdminResources), FactoryUrl: "/api/oauth/client/value/factory")]
+    public class OAuthClientSettingValue : IFormDescriptor, IValidateable
+    {
+        public string Id { get; set; } = Guid.NewGuid().ToId();
+
+        [FormField(LabelResource: UserAdminResources.Names.OAuthClientSettingValue_Value,
+            FieldType: FieldTypes.Text, ResourceType: typeof(UserAdminResources), IsRequired: true, IsUserEditable: true)]
+        public string Value { get; set; }
+
+        [CustomValidator]
+        public void Validate(ValidationResult result, Actions action)
+        {
+            if (String.IsNullOrWhiteSpace(Value))
+                result.AddUserError("Value is required.");
+        }
+
+        public List<string> GetFormFields()
+        {
+            return new List<string> { nameof(Value) };
+        }
+    }
+}

--- a/src/LagoVista.UserAdmin.Models/Resources/OAuthClientResources.resx
+++ b/src/LagoVista.UserAdmin.Models/Resources/OAuthClientResources.resx
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="OAuthClientApplication_Title" xml:space="preserve"><value>OAuth Client Application</value></data>
+  <data name="OAuthClientApplications_Title" xml:space="preserve"><value>OAuth Client Applications</value></data>
+  <data name="OAuthClientApplication_Help" xml:space="preserve"><value>Registers an external application that may request OAuth authorization and tokens.</value></data>
+  <data name="OAuthClientApplication_Description" xml:space="preserve"><value>Defines the redirect locations, grants, scopes, resources, security controls, and credentials available to an OAuth client.</value></data>
+  <data name="OAuthClientApplication_ClientId" xml:space="preserve"><value>Client ID</value></data>
+  <data name="OAuthClientApplication_ClientId_Help" xml:space="preserve"><value>Globally unique OAuth identifier presented by the client.</value></data>
+  <data name="OAuthClientApplication_ClientType" xml:space="preserve"><value>Client Type</value></data>
+  <data name="OAuthClientApplication_ClientType_Help" xml:space="preserve"><value>Public clients use PKCE and cannot safely hold a secret. Confidential clients authenticate at the token endpoint.</value></data>
+  <data name="OAuthClientApplication_ClientType_Select" xml:space="preserve"><value>Select a client type</value></data>
+  <data name="OAuthClientApplication_ClientType_Public" xml:space="preserve"><value>Public</value></data>
+  <data name="OAuthClientApplication_ClientType_Confidential" xml:space="preserve"><value>Confidential</value></data>
+  <data name="OAuthClientApplication_Status" xml:space="preserve"><value>Status</value></data>
+  <data name="OAuthClientApplication_Status_Help" xml:space="preserve"><value>Controls whether the authorization server accepts requests from this client.</value></data>
+  <data name="OAuthClientApplication_Status_Select" xml:space="preserve"><value>Select a status</value></data>
+  <data name="OAuthClientApplication_Status_Active" xml:space="preserve"><value>Active</value></data>
+  <data name="OAuthClientApplication_Status_Disabled" xml:space="preserve"><value>Disabled</value></data>
+  <data name="OAuthClientApplication_Status_Revoked" xml:space="preserve"><value>Revoked</value></data>
+  <data name="OAuthClientApplication_ClientSecret" xml:space="preserve"><value>Client Secret</value></data>
+  <data name="OAuthClientApplication_ClientSecret_Help" xml:space="preserve"><value>Credential for confidential clients. The plaintext value is stored in secure storage and is not persisted with this record.</value></data>
+  <data name="OAuthClientApplication_RedirectUris" xml:space="preserve"><value>Redirect URIs</value></data>
+  <data name="OAuthClientApplication_RedirectUris_Help" xml:space="preserve"><value>Exact callback locations to which authorization responses may be sent.</value></data>
+  <data name="OAuthClientApplication_PostLogoutRedirectUris" xml:space="preserve"><value>Post-Logout Redirect URIs</value></data>
+  <data name="OAuthClientApplication_PostLogoutRedirectUris_Help" xml:space="preserve"><value>Allowed destinations after a logout flow completes.</value></data>
+  <data name="OAuthClientApplication_AllowedGrantTypes" xml:space="preserve"><value>Allowed Grant Types</value></data>
+  <data name="OAuthClientApplication_AllowedGrantTypes_Help" xml:space="preserve"><value>OAuth grants available to this client, such as authorization_code and refresh_token.</value></data>
+  <data name="OAuthClientApplication_AllowedScopes" xml:space="preserve"><value>Allowed Scopes</value></data>
+  <data name="OAuthClientApplication_AllowedScopes_Help" xml:space="preserve"><value>Permissions this client is permitted to request.</value></data>
+  <data name="OAuthClientApplication_AllowedResources" xml:space="preserve"><value>Allowed Resources</value></data>
+  <data name="OAuthClientApplication_AllowedResources_Help" xml:space="preserve"><value>Resource servers for which this client may request access tokens.</value></data>
+  <data name="OAuthClientApplication_RequirePkce" xml:space="preserve"><value>Require PKCE</value></data>
+  <data name="OAuthClientApplication_RequirePkce_Help" xml:space="preserve"><value>Requires proof-key validation for authorization-code exchanges.</value></data>
+  <data name="OAuthClientApplication_RequireConsent" xml:space="preserve"><value>Require Consent</value></data>
+  <data name="OAuthClientApplication_RequireConsent_Help" xml:space="preserve"><value>Requires the user to approve the requested access.</value></data>
+  <data name="OAuthClientApplication_AccessTokenLifetimeMinutes" xml:space="preserve"><value>Access Token Lifetime (Minutes)</value></data>
+  <data name="OAuthClientApplication_AccessTokenLifetimeMinutes_Help" xml:space="preserve"><value>Optional client-specific access-token lifetime.</value></data>
+  <data name="OAuthClientApplication_RefreshTokenLifetimeDays" xml:space="preserve"><value>Refresh Token Lifetime (Days)</value></data>
+  <data name="OAuthClientApplication_RefreshTokenLifetimeDays_Help" xml:space="preserve"><value>Optional client-specific refresh-token lifetime.</value></data>
+  <data name="OAuthClientApplication_LogoUrl" xml:space="preserve"><value>Logo URL</value></data>
+  <data name="OAuthClientApplication_PrivacyPolicyUrl" xml:space="preserve"><value>Privacy Policy URL</value></data>
+  <data name="OAuthClientApplication_TermsOfServiceUrl" xml:space="preserve"><value>Terms of Service URL</value></data>
+  <data name="OAuthClientSettingValue_Title" xml:space="preserve"><value>OAuth Client Setting</value></data>
+  <data name="OAuthClientSettingValue_Help" xml:space="preserve"><value>A configured OAuth value such as a redirect URI, grant, scope, or resource.</value></data>
+  <data name="OAuthClientSettingValue_Value" xml:space="preserve"><value>Value</value></data>
+</root>

--- a/src/LagoVista.UserAdmin.Repos/Repos/Security/OAuthClientApplicationRepo.cs
+++ b/src/LagoVista.UserAdmin.Repos/Repos/Security/OAuthClientApplicationRepo.cs
@@ -1,0 +1,59 @@
+using LagoVista.CloudStorage.DocumentDB;
+using LagoVista.CloudStorage.Interfaces;
+using LagoVista.Core.Models.UIMetaData;
+using LagoVista.UserAdmin.Interfaces.Repos.Security;
+using LagoVista.UserAdmin.Models.Auth;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace LagoVista.UserAdmin.Repos.Repos.Security
+{
+    public class OAuthClientApplicationRepo : DocumentDBRepoBase<OAuthClientApplication>, IOAuthClientApplicationRepo
+    {
+        public OAuthClientApplicationRepo(IUserAdminSettings userAdminSettings, IDocumentCloudCachedServices services) :
+            base(userAdminSettings.UserStorage.Uri, userAdminSettings.UserStorage.AccessKey, userAdminSettings.UserStorage.ResourceName, services)
+        {
+        }
+
+        public Task AddOAuthClientApplicationAsync(OAuthClientApplication client)
+        {
+            return CreateDocumentAsync(client);
+        }
+
+        public Task UpdateOAuthClientApplicationAsync(OAuthClientApplication client)
+        {
+            return UpsertDocumentAsync(client);
+        }
+
+        public Task DeleteOAuthClientApplicationAsync(string id)
+        {
+            return DeleteDocumentAsync(id);
+        }
+
+        public Task<OAuthClientApplication> GetOAuthClientApplicationAsync(string id)
+        {
+            return GetDocumentAsync(id);
+        }
+
+        public async Task<OAuthClientApplication> GetOAuthClientApplicationByClientIdAsync(string clientId)
+        {
+            return (await QueryAsync(client => client.ClientId == clientId)).FirstOrDefault();
+        }
+
+        public Task<ListResponse<OAuthClientApplicationSummary>> GetOAuthClientApplicationsAsync(string orgId, ListRequest listRequest)
+        {
+            return QuerySummaryAsync<OAuthClientApplicationSummary, OAuthClientApplication>(client => client.OwnerOrganization.Id == orgId, client => client.Name, listRequest);
+        }
+
+        public async Task<bool> QueryKeyInUseAsync(string key, string orgId)
+        {
+            return (await QueryAsync(client => (client.OwnerOrganization.Id == orgId || client.IsPublic == true) && client.Key == key)).Any();
+        }
+
+        public async Task<bool> QueryClientIdInUseAsync(string clientId, string currentId = null)
+        {
+            var matches = await QueryAsync(client => client.ClientId == clientId);
+            return matches.Any(client => currentId == null || client.Id != currentId);
+        }
+    }
+}

--- a/src/LagoVista.UserAdmin.Repos/Startup.cs
+++ b/src/LagoVista.UserAdmin.Repos/Startup.cs
@@ -61,6 +61,7 @@ namespace LagoVista.UserAdmin.Repos
             services.AddScoped<IHolidaySetRepo, HolidaySetRepo>();
             services.AddScoped<IScheduledDowntimeRepo, ScheduledDowntimeRepo>();
             services.AddScoped<IScheduledDowntimeRepo, ScheduledDowntimeRepo>();
+            services.AddScoped<IOAuthClientApplicationRepo, OAuthClientApplicationRepo>();
             services.AddScoped<ITeamRepo, TeamRepo>();
             services.AddScoped<ITeamUserRepo, TeamUserRepo>();
             services.AddScoped<IAssetSetRepo, AssetSetRepo>();

--- a/src/LagoVista.UserAdmin/Interfaces/Managers/IOAuthClientApplicationManager.cs
+++ b/src/LagoVista.UserAdmin/Interfaces/Managers/IOAuthClientApplicationManager.cs
@@ -1,0 +1,21 @@
+using LagoVista.Core.Models;
+using LagoVista.Core.Models.UIMetaData;
+using LagoVista.Core.Validation;
+using LagoVista.UserAdmin.Models.Auth;
+using System.Threading.Tasks;
+
+namespace LagoVista.UserAdmin.Interfaces.Managers
+{
+    public interface IOAuthClientApplicationManager
+    {
+        Task<InvokeResult> AddOAuthClientApplicationAsync(OAuthClientApplication client, EntityHeader org, EntityHeader user);
+        Task<InvokeResult> UpdateOAuthClientApplicationAsync(OAuthClientApplication client, EntityHeader org, EntityHeader user);
+        Task<InvokeResult> DeleteOAuthClientApplicationAsync(string id, EntityHeader org, EntityHeader user);
+        Task<OAuthClientApplication> GetOAuthClientApplicationAsync(string id, EntityHeader org, EntityHeader user);
+        Task<OAuthClientApplication> GetOAuthClientApplicationByClientIdAsync(string clientId);
+        Task<ListResponse<OAuthClientApplicationSummary>> GetOAuthClientApplicationsForOrgAsync(EntityHeader org, EntityHeader user, ListRequest listRequest);
+        Task<bool> QueryKeyInUseAsync(string key, EntityHeader org);
+        Task<bool> QueryClientIdInUseAsync(string clientId, string currentId = null);
+        Task<DependentObjectCheckResult> CheckOAuthClientApplicationInUseAsync(string id, EntityHeader org, EntityHeader user);
+    }
+}

--- a/src/LagoVista.UserAdmin/Interfaces/Repos/Security/IOAuthClientApplicationRepo.cs
+++ b/src/LagoVista.UserAdmin/Interfaces/Repos/Security/IOAuthClientApplicationRepo.cs
@@ -1,0 +1,18 @@
+using LagoVista.Core.Models.UIMetaData;
+using LagoVista.UserAdmin.Models.Auth;
+using System.Threading.Tasks;
+
+namespace LagoVista.UserAdmin.Interfaces.Repos.Security
+{
+    public interface IOAuthClientApplicationRepo
+    {
+        Task AddOAuthClientApplicationAsync(OAuthClientApplication client);
+        Task UpdateOAuthClientApplicationAsync(OAuthClientApplication client);
+        Task DeleteOAuthClientApplicationAsync(string id);
+        Task<OAuthClientApplication> GetOAuthClientApplicationAsync(string id);
+        Task<OAuthClientApplication> GetOAuthClientApplicationByClientIdAsync(string clientId);
+        Task<ListResponse<OAuthClientApplicationSummary>> GetOAuthClientApplicationsAsync(string orgId, ListRequest listRequest);
+        Task<bool> QueryKeyInUseAsync(string key, string orgId);
+        Task<bool> QueryClientIdInUseAsync(string clientId, string currentId = null);
+    }
+}

--- a/src/LagoVista.UserAdmin/Managers/OAuthClientApplicationManager.cs
+++ b/src/LagoVista.UserAdmin/Managers/OAuthClientApplicationManager.cs
@@ -1,0 +1,133 @@
+using LagoVista.Core.Interfaces;
+using LagoVista.Core.Managers;
+using LagoVista.Core.Models;
+using LagoVista.Core.Models.UIMetaData;
+using LagoVista.Core.Validation;
+using LagoVista.IoT.Logging.Loggers;
+using LagoVista.UserAdmin.Interfaces.Managers;
+using LagoVista.UserAdmin.Interfaces.Repos.Security;
+using LagoVista.UserAdmin.Models.Auth;
+using System;
+using System.Threading.Tasks;
+using static LagoVista.Core.Models.AuthorizeResult;
+
+namespace LagoVista.UserAdmin.Managers
+{
+    public class OAuthClientApplicationManager : ManagerBase, IOAuthClientApplicationManager
+    {
+        private readonly IOAuthClientApplicationRepo _repo;
+        private readonly ISecureStorage _secureStorage;
+
+        public OAuthClientApplicationManager(IOAuthClientApplicationRepo repo, ISecureStorage secureStorage, IDependencyManager depManager,
+            ISecurity security, IAdminLogger logger, IAppConfig appConfig) : base(logger, appConfig, depManager, security)
+        {
+            _repo = repo ?? throw new ArgumentNullException(nameof(repo));
+            _secureStorage = secureStorage ?? throw new ArgumentNullException(nameof(secureStorage));
+        }
+
+        public async Task<InvokeResult> AddOAuthClientApplicationAsync(OAuthClientApplication client, EntityHeader org, EntityHeader user)
+        {
+            await AuthorizeAsync(client, AuthorizeActions.Create, user, org);
+            ValidationCheck(client, Actions.Create);
+
+            if (await _repo.QueryClientIdInUseAsync(client.ClientId))
+                return InvokeResult.FromError($"The OAuth client id [{client.ClientId}] is already registered.");
+
+            if (!String.IsNullOrEmpty(client.ClientSecret))
+            {
+                var secretResult = await _secureStorage.AddUserSecretAsync(client.ToEntityHeader(), client.ClientSecret);
+                if (!secretResult.Successful)
+                    return secretResult.ToInvokeResult();
+
+                client.ClientSecretId = secretResult.Result;
+                client.ClientSecret = null;
+            }
+
+            await _repo.AddOAuthClientApplicationAsync(client);
+            return InvokeResult.Success;
+        }
+
+        public async Task<InvokeResult> UpdateOAuthClientApplicationAsync(OAuthClientApplication client, EntityHeader org, EntityHeader user)
+        {
+            var existingClient = await _repo.GetOAuthClientApplicationAsync(client.Id);
+            await AuthorizeAsync(existingClient, AuthorizeActions.Update, user, org);
+
+            client.ClientSecretId = existingClient.ClientSecretId;
+            ValidationCheck(client, Actions.Update);
+
+            if (await _repo.QueryClientIdInUseAsync(client.ClientId, client.Id))
+                return InvokeResult.FromError($"The OAuth client id [{client.ClientId}] is already registered.");
+
+            var oldSecretId = existingClient.ClientSecretId;
+            if (!String.IsNullOrEmpty(client.ClientSecret))
+            {
+                var secretResult = await _secureStorage.AddUserSecretAsync(client.ToEntityHeader(), client.ClientSecret);
+                if (!secretResult.Successful)
+                    return secretResult.ToInvokeResult();
+
+                client.ClientSecretId = secretResult.Result;
+                client.ClientSecret = null;
+            }
+
+            await _repo.UpdateOAuthClientApplicationAsync(client);
+
+            if (!String.IsNullOrEmpty(oldSecretId) && oldSecretId != client.ClientSecretId)
+                await _secureStorage.RemoveUserSecretAsync(existingClient.ToEntityHeader(), oldSecretId);
+
+            return InvokeResult.Success;
+        }
+
+        public async Task<InvokeResult> DeleteOAuthClientApplicationAsync(string id, EntityHeader org, EntityHeader user)
+        {
+            var client = await _repo.GetOAuthClientApplicationAsync(id);
+            await AuthorizeAsync(client, AuthorizeActions.Delete, user, org);
+            await ConfirmNoDepenenciesAsync(client);
+
+            await _repo.DeleteOAuthClientApplicationAsync(id);
+
+            if (!String.IsNullOrEmpty(client.ClientSecretId))
+                await _secureStorage.RemoveUserSecretAsync(client.ToEntityHeader(), client.ClientSecretId);
+
+            return InvokeResult.Success;
+        }
+
+        public async Task<DependentObjectCheckResult> CheckOAuthClientApplicationInUseAsync(string id, EntityHeader org, EntityHeader user)
+        {
+            var client = await _repo.GetOAuthClientApplicationAsync(id);
+            await AuthorizeAsync(client, AuthorizeActions.Read, user, org);
+            return await CheckForDepenenciesAsync(client);
+        }
+
+        public async Task<OAuthClientApplication> GetOAuthClientApplicationAsync(string id, EntityHeader org, EntityHeader user)
+        {
+            var client = await _repo.GetOAuthClientApplicationAsync(id);
+            await AuthorizeAsync(client, AuthorizeActions.Read, user, org);
+            client.ClientSecret = null;
+            return client;
+        }
+
+        public async Task<OAuthClientApplication> GetOAuthClientApplicationByClientIdAsync(string clientId)
+        {
+            var client = await _repo.GetOAuthClientApplicationByClientIdAsync(clientId);
+            if (client != null)
+                client.ClientSecret = null;
+            return client;
+        }
+
+        public async Task<ListResponse<OAuthClientApplicationSummary>> GetOAuthClientApplicationsForOrgAsync(EntityHeader org, EntityHeader user, ListRequest listRequest)
+        {
+            await AuthorizeOrgAccessAsync(user, org.Id, typeof(OAuthClientApplication));
+            return await _repo.GetOAuthClientApplicationsAsync(org.Id, listRequest);
+        }
+
+        public Task<bool> QueryKeyInUseAsync(string key, EntityHeader org)
+        {
+            return _repo.QueryKeyInUseAsync(key, org.Id);
+        }
+
+        public Task<bool> QueryClientIdInUseAsync(string clientId, string currentId = null)
+        {
+            return _repo.QueryClientIdInUseAsync(clientId, currentId);
+        }
+    }
+}

--- a/src/LagoVista.UserAdmin/Startup.cs
+++ b/src/LagoVista.UserAdmin/Startup.cs
@@ -22,6 +22,7 @@ namespace LagoVista.UserAdmin
             services.AddScoped<ITeamManager, TeamManager>();
             services.AddScoped<IAssetSetManager, AssetSetManager>();
             services.AddScoped<IScheduledDowntimeManager, ScheduledDowntimeManager>();
+            services.AddScoped<IOAuthClientApplicationManager, OAuthClientApplicationManager>();
             services.AddScoped<IHolidaySetManager, HolidaySetManager>();
             services.AddScoped<ISubscriptionManager, SubscriptionManager>();
             services.AddScoped<IModuleManager, ModuleManager>();


### PR DESCRIPTION
## What changed

Adds the durable OAuth client registration substrate using the existing UserAdmin model, manager, repository, secure-storage, and metadata patterns.

- adds `OAuthClientApplication`, summary, client type/status enums, and child setting values
- adds complete form metadata for redirect URIs, grants, scopes, resources, PKCE, consent, token lifetimes, client metadata, and confidential-client secrets
- stores client secrets through `ISecureStorage` and persists only `ClientSecretId`
- adds manager and repository contracts and implementations
- enforces globally unique OAuth `ClientId` values
- registers the manager and Cosmos repository with dependency injection
- adds OAuth-specific RESX entries; the existing T4 resource generator produces the C# resource surface

## Why

This creates the configuration record that the future OAuth authorization-server module will use to validate client identity, redirect URIs, grant types, scopes, resources, and client security requirements.

## Notes

- Existing authentication and legacy access/refresh-token behavior is unchanged.
- Tests are intentionally deferred until the model and authorization-server integration stabilize.
- The REST maintenance controller is in the companion `UserAdminRest` PR.

## Validation

Reviewed the change set against the existing `ScheduledDowntime` CRUD pattern and the `AppUser.Ssn` secure-storage lifecycle. A local build was not available in this environment; the generated resource C# should be refreshed using the repository's normal T4 workflow before build validation.