### PR TITLE
Add OAuth authorization code vertical slice

### DIFF
--- a/docs/oauth-authorization-code-smoke-test.md
+++ b/docs/oauth-authorization-code-smoke-test.md
@@ -1,0 +1,97 @@
+# OAuth Authorization Code Smoke Test
+
+This smoke test proves the first OAuth vertical slice without requiring an MCP client.
+
+## Host registration
+
+Register the UserAdmin module first, followed by the authorization server module:
+
+```csharp
+services.AddUserAdminModule(configurationRoot, logger);
+
+services.AddLagoVistaAuthorizationServer(options =>
+{
+    options.Issuer = new Uri("https://localhost:5001/");
+    options.UseDevelopmentCertificates = true;
+    options.DisableAccessTokenEncryption = true;
+    options.Scopes.Add("knowledge.read");
+});
+```
+
+The ASP.NET Core host must call authentication and authorization middleware after routing and before endpoint mapping:
+
+```csharp
+app.UseRouting();
+app.UseAuthentication();
+app.UseAuthorization();
+app.MapControllers();
+```
+
+OpenIddict rejects non-HTTPS authorization-server requests by default. Use an HTTPS development endpoint.
+
+## Development OAuth client
+
+Create an active public `OAuthClientApplication` with these values:
+
+```text
+ClientId: lagovista-oauth-test
+ClientType: public
+Status: active
+RequirePkce: true
+RequireConsent: false
+RedirectUris:
+  http://127.0.0.1:8765/callback/
+AllowedGrantTypes:
+  authorization_code
+AllowedScopes:
+  knowledge.read
+AllowedResources:
+  https://localhost:5001/test-resource
+```
+
+The redirect URI comparison is exact, including scheme, host, port, path, and trailing slash.
+
+## Run the flow
+
+From the repository root in PowerShell 7:
+
+```powershell
+./tools/Test-OAuthAuthorizationCode.ps1 `
+  -Authority https://localhost:5001 `
+  -ClientId lagovista-oauth-test `
+  -Resource https://localhost:5001/test-resource `
+  -Scope knowledge.read
+```
+
+The harness:
+
+1. creates a cryptographically random PKCE verifier and S256 challenge;
+2. starts a localhost callback listener;
+3. opens the browser at `/connect/authorize`;
+4. uses the host's existing login challenge when no login cookie exists;
+5. validates the returned `state` value;
+6. exchanges the authorization code at `/connect/token`;
+7. calls `/api/oauth/whoami` using the access token.
+
+The final PowerShell object contains both the token response and the decoded identity returned by `whoami`.
+
+## Expected discovery endpoint
+
+The authorization server publishes metadata at:
+
+```text
+/.well-known/openid-configuration
+```
+
+The metadata should advertise `/connect/authorize`, `/connect/token`, authorization code flow, and S256 PKCE support.
+
+## Deferred behavior
+
+This slice does not yet implement:
+
+- persistent consent or authorization grants;
+- refresh tokens;
+- confidential-client secret validation;
+- revocation;
+- production signing certificate resolution;
+- MCP protected-resource metadata.

--- a/src/LagoVista.AspNetCore.AuthorizationServer/AuthorizationController.cs
+++ b/src/LagoVista.AspNetCore.AuthorizationServer/AuthorizationController.cs
@@ -1,0 +1,115 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Tokens;
+using OpenIddict.Abstractions;
+using OpenIddict.Server.AspNetCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using static OpenIddict.Abstractions.OpenIddictConstants;
+
+namespace LagoVista.AspNetCore.AuthorizationServer
+{
+    public class AuthorizationController : Controller
+    {
+        private readonly IOAuthClientPolicyResolver _policyResolver;
+        private readonly IOAuthClientPolicyValidator _policyValidator;
+
+        public AuthorizationController(IOAuthClientPolicyResolver policyResolver, IOAuthClientPolicyValidator policyValidator)
+        {
+            _policyResolver = policyResolver ?? throw new ArgumentNullException(nameof(policyResolver));
+            _policyValidator = policyValidator ?? throw new ArgumentNullException(nameof(policyValidator));
+        }
+
+        [HttpGet(AuthorizationServerConstants.AuthorizationEndpoint)]
+        [HttpPost(AuthorizationServerConstants.AuthorizationEndpoint)]
+        [IgnoreAntiforgeryToken]
+        public async Task<IActionResult> AuthorizeAsync()
+        {
+            var request = HttpContext.GetOpenIddictServerRequest();
+            if (request == null)
+                throw new InvalidOperationException("The OAuth authorization request could not be resolved.");
+
+            var policy = await _policyResolver.GetByClientIdAsync(request.ClientId);
+            if (policy == null || !policy.IsActive)
+                return Reject(Errors.UnauthorizedClient, "The OAuth client is unknown or disabled.");
+
+            if (!String.Equals(request.ResponseType, ResponseTypes.Code, StringComparison.Ordinal))
+                return Reject(Errors.UnsupportedResponseType, "Only the authorization code response type is supported.");
+
+            if (!_policyValidator.IsGrantTypeAllowed(policy, GrantTypes.AuthorizationCode))
+                return Reject(Errors.UnauthorizedClient, "The OAuth client is not permitted to use the authorization code flow.");
+
+            if (!_policyValidator.IsRedirectUriAllowed(policy, request.RedirectUri))
+                return Reject(Errors.InvalidRequest, "The redirect URI is not registered for this OAuth client.");
+
+            var scopes = request.GetScopes();
+            if (!_policyValidator.AreScopesAllowed(policy, scopes))
+                return Reject(Errors.InvalidScope, "One or more requested scopes are not permitted for this OAuth client.");
+
+            var resources = request.GetResources();
+            if (resources.Length != 1 || !_policyValidator.IsResourceAllowed(policy, resources[0]))
+                return Reject(Errors.InvalidTarget, "Exactly one registered resource must be requested.");
+
+            if (_policyValidator.IsPkceRequired(policy))
+            {
+                if (String.IsNullOrWhiteSpace(request.CodeChallenge))
+                    return Reject(Errors.InvalidRequest, "A PKCE code challenge is required.");
+
+                if (!String.Equals(request.CodeChallengeMethod, CodeChallengeMethods.Sha256, StringComparison.Ordinal))
+                    return Reject(Errors.InvalidRequest, "The PKCE code challenge method must be S256.");
+            }
+
+            var authentication = await HttpContext.AuthenticateAsync();
+            if (authentication?.Principal?.Identity?.IsAuthenticated != true)
+            {
+                return Challenge(new AuthenticationProperties
+                {
+                    RedirectUri = Request.GetEncodedUrl(),
+                });
+            }
+
+            var subject = authentication.Principal.FindFirstValue(ClaimTypes.NameIdentifier)
+                ?? authentication.Principal.FindFirstValue(Claims.Subject);
+
+            if (String.IsNullOrWhiteSpace(subject))
+                return Reject(Errors.AccessDenied, "The authenticated user does not have a stable subject identifier.");
+
+            var displayName = authentication.Principal.Identity.Name
+                ?? authentication.Principal.FindFirstValue(ClaimTypes.Email)
+                ?? subject;
+
+            var identity = new ClaimsIdentity(
+                TokenValidationParameters.DefaultAuthenticationType,
+                Claims.Name,
+                Claims.Role);
+
+            identity.AddClaim(new Claim(Claims.Subject, subject));
+            identity.AddClaim(new Claim(Claims.Name, displayName).SetDestinations(Destinations.AccessToken));
+            identity.AddClaim(new Claim(Claims.ClientId, policy.ClientId).SetDestinations(Destinations.AccessToken));
+
+            var principal = new ClaimsPrincipal(identity);
+            principal.SetScopes(scopes);
+            principal.SetResources(resources);
+
+            if (policy.AccessTokenLifetimeMinutes.HasValue && policy.AccessTokenLifetimeMinutes.Value > 0)
+                principal.SetAccessTokenLifetime(TimeSpan.FromMinutes(policy.AccessTokenLifetimeMinutes.Value));
+
+            return SignIn(principal, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+        }
+
+        private IActionResult Reject(string error, string description)
+        {
+            var properties = new AuthenticationProperties(new Dictionary<string, string>
+            {
+                [OpenIddictServerAspNetCoreConstants.Properties.Error] = error,
+                [OpenIddictServerAspNetCoreConstants.Properties.ErrorDescription] = description,
+            });
+
+            return Forbid(properties, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+        }
+    }
+}

--- a/src/LagoVista.AspNetCore.AuthorizationServer/AuthorizationServerConstants.cs
+++ b/src/LagoVista.AspNetCore.AuthorizationServer/AuthorizationServerConstants.cs
@@ -1,0 +1,15 @@
+namespace LagoVista.AspNetCore.AuthorizationServer
+{
+    public static class AuthorizationServerConstants
+    {
+        public const string AuthorizationEndpoint = "/connect/authorize";
+        public const string TokenEndpoint = "/connect/token";
+        public const string RevocationEndpoint = "/connect/revoke";
+
+        public const string GrantTypeAuthorizationCode = "authorization_code";
+        public const string GrantTypeRefreshToken = "refresh_token";
+
+        public const string ScopeOpenId = "openid";
+        public const string ScopeOfflineAccess = "offline_access";
+    }
+}

--- a/src/LagoVista.AspNetCore.AuthorizationServer/AuthorizationServerOptions.cs
+++ b/src/LagoVista.AspNetCore.AuthorizationServer/AuthorizationServerOptions.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+
+namespace LagoVista.AspNetCore.AuthorizationServer
+{
+    public class AuthorizationServerOptions
+    {
+        public Uri Issuer { get; set; }
+        public bool UseDevelopmentCertificates { get; set; }
+        public bool DisableAccessTokenEncryption { get; set; } = true;
+        public List<string> Scopes { get; set; } = new List<string>();
+    }
+}

--- a/src/LagoVista.AspNetCore.AuthorizationServer/AuthorizationServerOptions.cs
+++ b/src/LagoVista.AspNetCore.AuthorizationServer/AuthorizationServerOptions.cs
@@ -6,7 +6,7 @@ namespace LagoVista.AspNetCore.AuthorizationServer
     public class AuthorizationServerOptions
     {
         public Uri Issuer { get; set; }
-        public bool UseDevelopmentCertificates { get; set; }
+        public bool UseDevelopmentCertificates { get; set; } = true;
         public bool DisableAccessTokenEncryption { get; set; } = true;
         public List<string> Scopes { get; set; } = new List<string>();
     }

--- a/src/LagoVista.AspNetCore.AuthorizationServer/IOAuthClientPolicyResolver.cs
+++ b/src/LagoVista.AspNetCore.AuthorizationServer/IOAuthClientPolicyResolver.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace LagoVista.AspNetCore.AuthorizationServer
+{
+    public interface IOAuthClientPolicyResolver
+    {
+        Task<OAuthClientPolicy> GetByClientIdAsync(string clientId);
+    }
+}

--- a/src/LagoVista.AspNetCore.AuthorizationServer/IOAuthClientPolicyValidator.cs
+++ b/src/LagoVista.AspNetCore.AuthorizationServer/IOAuthClientPolicyValidator.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace LagoVista.AspNetCore.AuthorizationServer
+{
+    public interface IOAuthClientPolicyValidator
+    {
+        bool IsRedirectUriAllowed(OAuthClientPolicy policy, string redirectUri);
+        bool IsGrantTypeAllowed(OAuthClientPolicy policy, string grantType);
+        bool AreScopesAllowed(OAuthClientPolicy policy, IEnumerable<string> scopes);
+        bool IsResourceAllowed(OAuthClientPolicy policy, string resource);
+        bool IsPkceRequired(OAuthClientPolicy policy);
+    }
+}

--- a/src/LagoVista.AspNetCore.AuthorizationServer/LagoVista.AspNetCore.AuthorizationServer.csproj
+++ b/src/LagoVista.AspNetCore.AuthorizationServer/LagoVista.AspNetCore.AuthorizationServer.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="OpenIddict.Server.AspNetCore" Version="7.6.0" />
+    <PackageReference Include="OpenIddict.Validation.AspNetCore" Version="7.6.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\LagoVista.AspNetCore.Identity\LagoVista.AspNetCore.Identity.csproj" />

--- a/src/LagoVista.AspNetCore.AuthorizationServer/LagoVista.AspNetCore.AuthorizationServer.csproj
+++ b/src/LagoVista.AspNetCore.AuthorizationServer/LagoVista.AspNetCore.AuthorizationServer.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="OpenIddict.Server.AspNetCore" Version="7.6.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\LagoVista.AspNetCore.Identity\LagoVista.AspNetCore.Identity.csproj" />
+    <ProjectReference Include="..\LagoVista.UserAdmin\LagoVista.UserAdmin.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/LagoVista.AspNetCore.AuthorizationServer/OAuthClientPolicy.cs
+++ b/src/LagoVista.AspNetCore.AuthorizationServer/OAuthClientPolicy.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+
+namespace LagoVista.AspNetCore.AuthorizationServer
+{
+    public class OAuthClientPolicy
+    {
+        public string Id { get; set; }
+        public string ClientId { get; set; }
+        public string Name { get; set; }
+        public string ClientType { get; set; }
+        public string Status { get; set; }
+        public bool RequirePkce { get; set; }
+        public bool RequireConsent { get; set; }
+        public string ClientSecretId { get; set; }
+        public int? AccessTokenLifetimeMinutes { get; set; }
+        public int? RefreshTokenLifetimeDays { get; set; }
+        public IReadOnlyCollection<string> RedirectUris { get; set; } = Array.Empty<string>();
+        public IReadOnlyCollection<string> PostLogoutRedirectUris { get; set; } = Array.Empty<string>();
+        public IReadOnlyCollection<string> AllowedGrantTypes { get; set; } = Array.Empty<string>();
+        public IReadOnlyCollection<string> AllowedScopes { get; set; } = Array.Empty<string>();
+        public IReadOnlyCollection<string> AllowedResources { get; set; } = Array.Empty<string>();
+
+        public bool IsActive => String.Equals(Status, "active", StringComparison.OrdinalIgnoreCase);
+        public bool IsPublicClient => String.Equals(ClientType, "public", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/LagoVista.AspNetCore.AuthorizationServer/OAuthClientPolicyResolver.cs
+++ b/src/LagoVista.AspNetCore.AuthorizationServer/OAuthClientPolicyResolver.cs
@@ -1,0 +1,56 @@
+using LagoVista.UserAdmin.Interfaces.Managers;
+using LagoVista.UserAdmin.Models.Auth;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace LagoVista.AspNetCore.AuthorizationServer
+{
+    public class OAuthClientPolicyResolver : IOAuthClientPolicyResolver
+    {
+        private readonly IOAuthClientApplicationManager _clientManager;
+
+        public OAuthClientPolicyResolver(IOAuthClientApplicationManager clientManager)
+        {
+            _clientManager = clientManager ?? throw new ArgumentNullException(nameof(clientManager));
+        }
+
+        public async Task<OAuthClientPolicy> GetByClientIdAsync(string clientId)
+        {
+            if (String.IsNullOrWhiteSpace(clientId))
+                return null;
+
+            var client = await _clientManager.GetOAuthClientApplicationByClientIdAsync(clientId);
+            if (client == null)
+                return null;
+
+            return new OAuthClientPolicy
+            {
+                Id = client.Id,
+                ClientId = client.ClientId,
+                Name = client.Name,
+                ClientType = client.ClientType?.Id,
+                Status = client.Status?.Id,
+                RequirePkce = client.RequirePkce,
+                RequireConsent = client.RequireConsent,
+                ClientSecretId = client.ClientSecretId,
+                AccessTokenLifetimeMinutes = client.AccessTokenLifetimeMinutes,
+                RefreshTokenLifetimeDays = client.RefreshTokenLifetimeDays,
+                RedirectUris = GetValues(client.RedirectUris),
+                PostLogoutRedirectUris = GetValues(client.PostLogoutRedirectUris),
+                AllowedGrantTypes = GetValues(client.AllowedGrantTypes),
+                AllowedScopes = GetValues(client.AllowedScopes),
+                AllowedResources = GetValues(client.AllowedResources),
+            };
+        }
+
+        private static string[] GetValues(System.Collections.Generic.IEnumerable<OAuthClientSettingValue> values)
+        {
+            return values?
+                .Where(value => value != null && !String.IsNullOrWhiteSpace(value.Value))
+                .Select(value => value.Value)
+                .Distinct(StringComparer.Ordinal)
+                .ToArray() ?? Array.Empty<string>();
+        }
+    }
+}

--- a/src/LagoVista.AspNetCore.AuthorizationServer/OAuthClientPolicyValidator.cs
+++ b/src/LagoVista.AspNetCore.AuthorizationServer/OAuthClientPolicyValidator.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LagoVista.AspNetCore.AuthorizationServer
+{
+    public class OAuthClientPolicyValidator : IOAuthClientPolicyValidator
+    {
+        public bool IsRedirectUriAllowed(OAuthClientPolicy policy, string redirectUri)
+        {
+            return IsUsable(policy) && !String.IsNullOrWhiteSpace(redirectUri) &&
+                policy.RedirectUris.Contains(redirectUri, StringComparer.Ordinal);
+        }
+
+        public bool IsGrantTypeAllowed(OAuthClientPolicy policy, string grantType)
+        {
+            return IsUsable(policy) && !String.IsNullOrWhiteSpace(grantType) &&
+                policy.AllowedGrantTypes.Contains(grantType, StringComparer.Ordinal);
+        }
+
+        public bool AreScopesAllowed(OAuthClientPolicy policy, IEnumerable<string> scopes)
+        {
+            if (!IsUsable(policy)) return false;
+
+            var requestedScopes = scopes?
+                .Where(scope => !String.IsNullOrWhiteSpace(scope))
+                .Distinct(StringComparer.Ordinal)
+                .ToArray() ?? Array.Empty<string>();
+
+            return requestedScopes.All(scope => policy.AllowedScopes.Contains(scope, StringComparer.Ordinal));
+        }
+
+        public bool IsResourceAllowed(OAuthClientPolicy policy, string resource)
+        {
+            return IsUsable(policy) && !String.IsNullOrWhiteSpace(resource) &&
+                policy.AllowedResources.Contains(resource, StringComparer.Ordinal);
+        }
+
+        public bool IsPkceRequired(OAuthClientPolicy policy)
+        {
+            return IsUsable(policy) && (policy.IsPublicClient || policy.RequirePkce);
+        }
+
+        private static bool IsUsable(OAuthClientPolicy policy)
+        {
+            return policy != null && policy.IsActive;
+        }
+    }
+}

--- a/src/LagoVista.AspNetCore.AuthorizationServer/OAuthWhoAmIController.cs
+++ b/src/LagoVista.AspNetCore.AuthorizationServer/OAuthWhoAmIController.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using OpenIddict.Abstractions;
+using OpenIddict.Validation.AspNetCore;
+using System.Linq;
+using static OpenIddict.Abstractions.OpenIddictConstants;
+
+namespace LagoVista.AspNetCore.AuthorizationServer
+{
+    public class OAuthWhoAmIController : Controller
+    {
+        [Authorize(AuthenticationSchemes = OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme)]
+        [HttpGet("/api/oauth/whoami")]
+        public IActionResult GetWhoAmI()
+        {
+            return Ok(new
+            {
+                Subject = User.GetClaim(Claims.Subject),
+                Name = User.GetClaim(Claims.Name),
+                ClientId = User.GetClaim(Claims.ClientId),
+                Scopes = User.GetScopes().ToArray(),
+                Resources = User.GetResources().ToArray(),
+                Claims = User.Claims.Select(claim => new
+                {
+                    claim.Type,
+                    claim.Value,
+                }).ToArray(),
+            });
+        }
+    }
+}

--- a/src/LagoVista.AspNetCore.AuthorizationServer/Startup.cs
+++ b/src/LagoVista.AspNetCore.AuthorizationServer/Startup.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.DependencyInjection;
-using OpenIddict.Abstractions;
 using System;
 using System.Linq;
 
@@ -16,6 +15,7 @@ namespace LagoVista.AspNetCore.AuthorizationServer
 
             services.AddSingleton(settings);
             services.AddScoped<IOAuthClientPolicyResolver, OAuthClientPolicyResolver>();
+            services.AddScoped<IOAuthClientPolicyValidator, OAuthClientPolicyValidator>();
 
             services.AddOpenIddict()
                 .AddServer(options =>

--- a/src/LagoVista.AspNetCore.AuthorizationServer/Startup.cs
+++ b/src/LagoVista.AspNetCore.AuthorizationServer/Startup.cs
@@ -1,0 +1,69 @@
+using Microsoft.Extensions.DependencyInjection;
+using OpenIddict.Abstractions;
+using System;
+using System.Linq;
+
+namespace LagoVista.AspNetCore.AuthorizationServer
+{
+    public static class Startup
+    {
+        public static void ConfigureServices(IServiceCollection services, Action<AuthorizationServerOptions> configure)
+        {
+            if (services == null) throw new ArgumentNullException(nameof(services));
+
+            var settings = new AuthorizationServerOptions();
+            configure?.Invoke(settings);
+
+            services.AddSingleton(settings);
+            services.AddScoped<IOAuthClientPolicyResolver, OAuthClientPolicyResolver>();
+
+            services.AddOpenIddict()
+                .AddServer(options =>
+                {
+                    options.EnableDegradedMode();
+
+                    options.SetAuthorizationEndpointUris(AuthorizationServerConstants.AuthorizationEndpoint)
+                           .SetTokenEndpointUris(AuthorizationServerConstants.TokenEndpoint);
+
+                    options.AllowAuthorizationCodeFlow();
+                    options.RequireProofKeyForCodeExchange();
+
+                    var scopes = settings.Scopes
+                        .Where(scope => !String.IsNullOrWhiteSpace(scope))
+                        .Distinct(StringComparer.Ordinal)
+                        .ToArray();
+
+                    if (scopes.Length > 0)
+                        options.RegisterScopes(scopes);
+
+                    if (settings.Issuer != null)
+                        options.SetIssuer(settings.Issuer);
+
+                    if (settings.UseDevelopmentCertificates)
+                    {
+                        options.AddDevelopmentEncryptionCertificate()
+                               .AddDevelopmentSigningCertificate();
+                    }
+
+                    if (settings.DisableAccessTokenEncryption)
+                        options.DisableAccessTokenEncryption();
+
+                    options.UseAspNetCore()
+                           .EnableStatusCodePagesIntegration()
+                           .EnableAuthorizationEndpointPassthrough()
+                           .EnableTokenEndpointPassthrough();
+                });
+        }
+    }
+}
+
+namespace LagoVista.DependencyInjection
+{
+    public static class LagoVistaAuthorizationServerModule
+    {
+        public static void AddLagoVistaAuthorizationServer(this IServiceCollection services, Action<LagoVista.AspNetCore.AuthorizationServer.AuthorizationServerOptions> configure)
+        {
+            LagoVista.AspNetCore.AuthorizationServer.Startup.ConfigureServices(services, configure);
+        }
+    }
+}

--- a/src/LagoVista.AspNetCore.AuthorizationServer/Startup.cs
+++ b/src/LagoVista.AspNetCore.AuthorizationServer/Startup.cs
@@ -17,10 +17,14 @@ namespace LagoVista.AspNetCore.AuthorizationServer
             services.AddScoped<IOAuthClientPolicyResolver, OAuthClientPolicyResolver>();
             services.AddScoped<IOAuthClientPolicyValidator, OAuthClientPolicyValidator>();
 
+            services.AddControllers()
+                .AddApplicationPart(typeof(AuthorizationController).Assembly);
+
             services.AddOpenIddict()
                 .AddServer(options =>
                 {
                     options.EnableDegradedMode();
+                    options.AcceptAnonymousClients();
 
                     options.SetAuthorizationEndpointUris(AuthorizationServerConstants.AuthorizationEndpoint)
                            .SetTokenEndpointUris(AuthorizationServerConstants.TokenEndpoint);
@@ -50,8 +54,12 @@ namespace LagoVista.AspNetCore.AuthorizationServer
 
                     options.UseAspNetCore()
                            .EnableStatusCodePagesIntegration()
-                           .EnableAuthorizationEndpointPassthrough()
-                           .EnableTokenEndpointPassthrough();
+                           .EnableAuthorizationEndpointPassthrough();
+                })
+                .AddValidation(options =>
+                {
+                    options.UseLocalServer();
+                    options.UseAspNetCore();
                 });
         }
     }

--- a/tools/Test-OAuthAuthorizationCode.ps1
+++ b/tools/Test-OAuthAuthorizationCode.ps1
@@ -20,6 +20,32 @@ function ConvertTo-Base64Url {
     return [Convert]::ToBase64String($Bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
 }
 
+function ConvertTo-QueryString {
+    param([hashtable]$Values)
+
+    return ($Values.GetEnumerator() |
+        Sort-Object Key |
+        ForEach-Object {
+            "{0}={1}" -f [Uri]::EscapeDataString([string]$_.Key), [Uri]::EscapeDataString([string]$_.Value)
+        }) -join '&'
+}
+
+function Get-QueryValue {
+    param(
+        [Uri]$Uri,
+        [string]$Name
+    )
+
+    foreach ($item in $Uri.Query.TrimStart('?').Split('&', [StringSplitOptions]::RemoveEmptyEntries)) {
+        $parts = $item.Split('=', 2)
+        if ([Uri]::UnescapeDataString($parts[0]) -eq $Name) {
+            return [Uri]::UnescapeDataString($parts[1])
+        }
+    }
+
+    return $null
+}
+
 function New-CodeVerifier {
     $bytes = New-Object byte[] 64
     [Security.Cryptography.RandomNumberGenerator]::Fill($bytes)
@@ -37,17 +63,18 @@ $challengeBytes = [Security.Cryptography.SHA256]::HashData($verifierBytes)
 $challenge = ConvertTo-Base64Url $challengeBytes
 $state = [Guid]::NewGuid().ToString("N")
 
-$query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
-$query["client_id"] = $ClientId
-$query["redirect_uri"] = $RedirectUri
-$query["response_type"] = "code"
-$query["scope"] = $Scope
-$query["resource"] = $Resource
-$query["code_challenge"] = $challenge
-$query["code_challenge_method"] = "S256"
-$query["state"] = $state
+$query = ConvertTo-QueryString @{
+    client_id = $ClientId
+    redirect_uri = $RedirectUri
+    response_type = "code"
+    scope = $Scope
+    resource = $Resource
+    code_challenge = $challenge
+    code_challenge_method = "S256"
+    state = $state
+}
 
-$authorizationUrl = "$authorizeUri?$($query.ToString())"
+$authorizationUrl = "$authorizeUri?$query"
 $listener = [Net.HttpListener]::new()
 $listener.Prefixes.Add($RedirectUri)
 
@@ -66,20 +93,18 @@ try {
     $context.Response.OutputStream.Write($responseBytes, 0, $responseBytes.Length)
     $context.Response.Close()
 
-    $returnedState = $callback.Query.TrimStart('?').Split('&') |
-        ForEach-Object { $_.Split('=', 2) } |
-        Where-Object { $_[0] -eq 'state' } |
-        ForEach-Object { [Uri]::UnescapeDataString($_[1]) }
-
+    $returnedState = Get-QueryValue -Uri $callback -Name "state"
     if ($returnedState -ne $state) {
         throw "OAuth state validation failed."
     }
 
-    $code = $callback.Query.TrimStart('?').Split('&') |
-        ForEach-Object { $_.Split('=', 2) } |
-        Where-Object { $_[0] -eq 'code' } |
-        ForEach-Object { [Uri]::UnescapeDataString($_[1]) }
+    $error = Get-QueryValue -Uri $callback -Name "error"
+    if (![String]::IsNullOrWhiteSpace($error)) {
+        $description = Get-QueryValue -Uri $callback -Name "error_description"
+        throw "OAuth authorization failed: $error $description"
+    }
 
+    $code = Get-QueryValue -Uri $callback -Name "code"
     if ([String]::IsNullOrWhiteSpace($code)) {
         throw "The callback did not contain an authorization code: $callback"
     }

--- a/tools/Test-OAuthAuthorizationCode.ps1
+++ b/tools/Test-OAuthAuthorizationCode.ps1
@@ -1,0 +1,112 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Authority,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ClientId,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Resource,
+
+    [string]$Scope = "knowledge.read",
+    [string]$RedirectUri = "http://127.0.0.1:8765/callback/"
+)
+
+$ErrorActionPreference = "Stop"
+
+function ConvertTo-Base64Url {
+    param([byte[]]$Bytes)
+
+    return [Convert]::ToBase64String($Bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
+}
+
+function New-CodeVerifier {
+    $bytes = New-Object byte[] 64
+    [Security.Cryptography.RandomNumberGenerator]::Fill($bytes)
+    return ConvertTo-Base64Url $bytes
+}
+
+$authorityUri = [Uri]$Authority
+$authorizeUri = [Uri]::new($authorityUri, "/connect/authorize")
+$tokenUri = [Uri]::new($authorityUri, "/connect/token")
+$whoAmIUri = [Uri]::new($authorityUri, "/api/oauth/whoami")
+
+$verifier = New-CodeVerifier
+$verifierBytes = [Text.Encoding]::ASCII.GetBytes($verifier)
+$challengeBytes = [Security.Cryptography.SHA256]::HashData($verifierBytes)
+$challenge = ConvertTo-Base64Url $challengeBytes
+$state = [Guid]::NewGuid().ToString("N")
+
+$query = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+$query["client_id"] = $ClientId
+$query["redirect_uri"] = $RedirectUri
+$query["response_type"] = "code"
+$query["scope"] = $Scope
+$query["resource"] = $Resource
+$query["code_challenge"] = $challenge
+$query["code_challenge_method"] = "S256"
+$query["state"] = $state
+
+$authorizationUrl = "$authorizeUri?$($query.ToString())"
+$listener = [Net.HttpListener]::new()
+$listener.Prefixes.Add($RedirectUri)
+
+try {
+    $listener.Start()
+    Write-Host "Opening authorization request..."
+    Write-Host $authorizationUrl
+    Start-Process $authorizationUrl
+
+    $context = $listener.GetContext()
+    $callback = $context.Request.Url
+    $responseText = "OAuth callback received. You may close this browser window."
+    $responseBytes = [Text.Encoding]::UTF8.GetBytes($responseText)
+    $context.Response.ContentType = "text/plain; charset=utf-8"
+    $context.Response.ContentLength64 = $responseBytes.Length
+    $context.Response.OutputStream.Write($responseBytes, 0, $responseBytes.Length)
+    $context.Response.Close()
+
+    $returnedState = $callback.Query.TrimStart('?').Split('&') |
+        ForEach-Object { $_.Split('=', 2) } |
+        Where-Object { $_[0] -eq 'state' } |
+        ForEach-Object { [Uri]::UnescapeDataString($_[1]) }
+
+    if ($returnedState -ne $state) {
+        throw "OAuth state validation failed."
+    }
+
+    $code = $callback.Query.TrimStart('?').Split('&') |
+        ForEach-Object { $_.Split('=', 2) } |
+        Where-Object { $_[0] -eq 'code' } |
+        ForEach-Object { [Uri]::UnescapeDataString($_[1]) }
+
+    if ([String]::IsNullOrWhiteSpace($code)) {
+        throw "The callback did not contain an authorization code: $callback"
+    }
+
+    $token = Invoke-RestMethod -Method Post -Uri $tokenUri -ContentType "application/x-www-form-urlencoded" -Body @{
+        grant_type = "authorization_code"
+        client_id = $ClientId
+        code = $code
+        redirect_uri = $RedirectUri
+        code_verifier = $verifier
+        resource = $Resource
+    }
+
+    Write-Host "Access token received. Calling whoami..."
+    $whoAmI = Invoke-RestMethod -Method Get -Uri $whoAmIUri -Headers @{
+        Authorization = "Bearer $($token.access_token)"
+    }
+
+    [PSCustomObject]@{
+        Token = $token
+        WhoAmI = $whoAmI
+    }
+}
+finally {
+    if ($listener.IsListening) {
+        $listener.Stop()
+    }
+
+    $listener.Close()
+}


### PR DESCRIPTION
## What changed

Adds the first executable OAuth authorization-code flow on top of the durable OAuth client registration substrate.

### Authorization-server module

- adds `LagoVista.AspNetCore.AuthorizationServer` targeting .NET 9
- references OpenIddict Server and Validation ASP.NET Core 7.6
- configures authorization-code flow, globally required PKCE, discovery metadata, development signing/encryption certificates, and local access-token validation
- uses OpenIddict degraded mode so LagoVista remains the system of record for clients instead of introducing OpenIddict EF stores
- exposes `AddLagoVistaAuthorizationServer(...)` and registers its controllers as an MVC application part

### LagoVista client policy

- projects `OAuthClientApplication` into a protocol-facing `OAuthClientPolicy`
- resolves clients through `IOAuthClientApplicationManager`
- validates active status, exact redirect URI, authorization-code grant permission, requested scopes, one requested resource, and S256 PKCE

### Executable flow

- adds `/connect/authorize`, reusing the host's existing authentication challenge/cookie
- issues an OpenIddict authorization code containing the authenticated LagoVista subject, approved scopes, resource, client ID, and optional client-specific access-token lifetime
- lets OpenIddict perform authorization-code redemption and PKCE verifier validation at `/connect/token`
- adds protected `/api/oauth/whoami` using OpenIddict local token validation
- adds a PowerShell 7 PKCE harness that opens the browser, receives the localhost callback, validates `state`, exchanges the code, and calls `whoami`
- adds a smoke-test guide with the exact host registration and development OAuth client values

## Why

This proves the full browser-based authorization-code thread before introducing ChatGPT or MCP as the client. It keeps user authentication, client registration, tenant policy, and secret ownership in the existing UserAdmin stack while OpenIddict handles OAuth wire semantics, authorization-code protection, PKCE redemption, signing, discovery, and access-token validation.

## Deliberately deferred

- persistent consent and user authorization records
- refresh tokens and revocation
- confidential-client secret validation
- production signing certificate resolution
- MCP protected-resource metadata
- ChatGPT interoperability testing

## Validation

The flow follows OpenIddict 7.6 ASP.NET Core pass-through and local-server validation guidance. The execution sandbox could not resolve GitHub for a local checkout, so the branch has not been compiled here.

After pulling the branch:

```powershell
dotnet sln UserAdmin.sln add src/LagoVista.AspNetCore.AuthorizationServer/LagoVista.AspNetCore.AuthorizationServer.csproj
dotnet build src/LagoVista.AspNetCore.AuthorizationServer/LagoVista.AspNetCore.AuthorizationServer.csproj
```

Then follow `docs/oauth-authorization-code-smoke-test.md` to register `lagovista-oauth-test` and run `tools/Test-OAuthAuthorizationCode.ps1`.