### PR TITLE
Add OIDC end-session endpoint

### DIFF
--- a/src/LagoVista.AspNetCore.AuthorizationServer/AuthorizationController.cs
+++ b/src/LagoVista.AspNetCore.AuthorizationServer/AuthorizationController.cs
@@ -120,6 +120,20 @@ namespace LagoVista.AspNetCore.AuthorizationServer
             return SignIn(principal, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
         }
 
+        [HttpGet(AuthorizationServerConstants.EndSessionEndpoint)]
+        [HttpPost(AuthorizationServerConstants.EndSessionEndpoint)]
+        [IgnoreAntiforgeryToken]
+        public async Task<IActionResult> LogoutAsync()
+        {
+            var request = HttpContext.GetOpenIddictServerRequest();
+            if (request == null)
+                throw new InvalidOperationException("The OIDC end session request could not be resolved.");
+
+            await HttpContext.SignOutAsync();
+
+            return SignOut(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+        }
+
         private IActionResult Reject(string error, string description)
         {
             var properties = new AuthenticationProperties(new Dictionary<string, string>

--- a/src/LagoVista.AspNetCore.AuthorizationServer/AuthorizationController.cs
+++ b/src/LagoVista.AspNetCore.AuthorizationServer/AuthorizationController.cs
@@ -131,9 +131,8 @@ namespace LagoVista.AspNetCore.AuthorizationServer
 
             // This is a protocol endpoint, so ASP.NET antiforgery validation is intentionally not used.
             // Requiring an OpenID Connect id_token_hint prevents a bare cross-site request from silently
-            // terminating the local NuvIoT browser session. OpenIddict validates the protocol request
-            // before endpoint passthrough; registered post-logout redirects are validated by the
-            // UserAdmin-backed OpenIddict application store.
+            // terminating the local NuvIoT browser session. Registered post-logout redirects are still
+            // validated through the UserAdmin-backed OpenIddict application store.
             if (String.IsNullOrWhiteSpace(request.IdTokenHint))
                 return Reject(Errors.InvalidRequest, "An id_token_hint is required to terminate the NuvIoT authentication session.");
 

--- a/src/LagoVista.AspNetCore.AuthorizationServer/AuthorizationController.cs
+++ b/src/LagoVista.AspNetCore.AuthorizationServer/AuthorizationController.cs
@@ -129,6 +129,14 @@ namespace LagoVista.AspNetCore.AuthorizationServer
             if (request == null)
                 throw new InvalidOperationException("The OIDC end session request could not be resolved.");
 
+            // This is a protocol endpoint, so ASP.NET antiforgery validation is intentionally not used.
+            // Requiring an OpenID Connect id_token_hint prevents a bare cross-site request from silently
+            // terminating the local NuvIoT browser session. OpenIddict validates the protocol request
+            // before endpoint passthrough; registered post-logout redirects are validated by the
+            // UserAdmin-backed OpenIddict application store.
+            if (String.IsNullOrWhiteSpace(request.IdTokenHint))
+                return Reject(Errors.InvalidRequest, "An id_token_hint is required to terminate the NuvIoT authentication session.");
+
             await HttpContext.SignOutAsync();
 
             return SignOut(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);

--- a/src/LagoVista.AspNetCore.AuthorizationServer/AuthorizationServerConstants.cs
+++ b/src/LagoVista.AspNetCore.AuthorizationServer/AuthorizationServerConstants.cs
@@ -5,6 +5,7 @@ namespace LagoVista.AspNetCore.AuthorizationServer
         public const string AuthorizationEndpoint = "/connect/authorize";
         public const string TokenEndpoint = "/connect/token";
         public const string UserInfoEndpoint = "/connect/userinfo";
+        public const string EndSessionEndpoint = "/connect/logout";
         public const string RevocationEndpoint = "/connect/revoke";
 
         public const string GrantTypeAuthorizationCode = "authorization_code";

--- a/src/LagoVista.AspNetCore.AuthorizationServer/Persistence/UserAdmin/OpenIddictOAuthClientApplicationStore.cs
+++ b/src/LagoVista.AspNetCore.AuthorizationServer/Persistence/UserAdmin/OpenIddictOAuthClientApplicationStore.cs
@@ -51,8 +51,21 @@ namespace LagoVista.AspNetCore.AuthorizationServer.Persistence.UserAdmin
         public ValueTask<OAuthClientApplication> FindByClientIdAsync(string identifier, CancellationToken cancellationToken)
             => FindByClientIdentifierAsync(identifier, cancellationToken);
 
-        public IAsyncEnumerable<OAuthClientApplication> FindByPostLogoutRedirectUriAsync(string uri, CancellationToken cancellationToken)
-            => throw ReadOnlyQueryNotSupported();
+        public async IAsyncEnumerable<OAuthClientApplication> FindByPostLogoutRedirectUriAsync(
+            string uri, [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            if (String.IsNullOrWhiteSpace(uri))
+                throw new ArgumentNullException(nameof(uri));
+
+            cancellationToken.ThrowIfCancellationRequested();
+            var applications = await _manager.GetOAuthClientApplicationsByPostLogoutRedirectUriAsync(uri);
+
+            foreach (var application in applications)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return application;
+            }
+        }
 
         public IAsyncEnumerable<OAuthClientApplication> FindByRedirectUriAsync(string uri, CancellationToken cancellationToken)
             => throw ReadOnlyQueryNotSupported();
@@ -109,10 +122,13 @@ namespace LagoVista.AspNetCore.AuthorizationServer.Persistence.UserAdmin
 
             var permissions = ImmutableArray.CreateBuilder<string>();
 
-            // The authorization-code slice requires both endpoints and the code response type.
+            // The authorization-code slice requires the interactive endpoints, token endpoint,
+            // authorization-code grant and code response type. End-session is part of the same
+            // browser-facing OIDC client capability and does not revoke already-issued tokens.
             if (Values(application.AllowedGrantTypes).Contains(OpenIddictConstants.GrantTypes.AuthorizationCode, StringComparer.Ordinal))
             {
                 permissions.Add(OpenIddictConstants.Permissions.Endpoints.Authorization);
+                permissions.Add(OpenIddictConstants.Permissions.Endpoints.EndSession);
                 permissions.Add(OpenIddictConstants.Permissions.Endpoints.Token);
                 permissions.Add(OpenIddictConstants.Permissions.GrantTypes.AuthorizationCode);
                 permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.Code);

--- a/src/LagoVista.AspNetCore.AuthorizationServer/Startup.cs
+++ b/src/LagoVista.AspNetCore.AuthorizationServer/Startup.cs
@@ -39,7 +39,8 @@ namespace LagoVista.AspNetCore.AuthorizationServer
 
                     options.SetAuthorizationEndpointUris(AuthorizationServerConstants.AuthorizationEndpoint)
                            .SetTokenEndpointUris(AuthorizationServerConstants.TokenEndpoint)
-                           .SetUserInfoEndpointUris(AuthorizationServerConstants.UserInfoEndpoint);
+                           .SetUserInfoEndpointUris(AuthorizationServerConstants.UserInfoEndpoint)
+                           .SetEndSessionEndpointUris(AuthorizationServerConstants.EndSessionEndpoint);
 
                     options.AllowAuthorizationCodeFlow();
                     options.RequireProofKeyForCodeExchange();
@@ -83,6 +84,7 @@ namespace LagoVista.AspNetCore.AuthorizationServer
                     options.UseAspNetCore()
                            .EnableStatusCodePagesIntegration()
                            .EnableAuthorizationEndpointPassthrough()
+                           .EnableEndSessionEndpointPassthrough()
                            .EnableUserInfoEndpointPassthrough();
                 })
                 .AddValidation(options =>

--- a/src/LagoVista.UserAdmin.Repos/Repos/Security/OAuthClientApplicationRepo.cs
+++ b/src/LagoVista.UserAdmin.Repos/Repos/Security/OAuthClientApplicationRepo.cs
@@ -3,6 +3,7 @@ using LagoVista.CloudStorage.Interfaces;
 using LagoVista.Core.Models.UIMetaData;
 using LagoVista.UserAdmin.Interfaces.Repos.Security;
 using LagoVista.UserAdmin.Models.Auth;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -38,6 +39,11 @@ namespace LagoVista.UserAdmin.Repos.Repos.Security
         public async Task<OAuthClientApplication> GetOAuthClientApplicationByClientIdAsync(string clientId)
         {
             return (await QueryAsync(client => client.ClientId == clientId)).FirstOrDefault();
+        }
+
+        public async Task<List<OAuthClientApplication>> GetOAuthClientApplicationsByPostLogoutRedirectUriAsync(string postLogoutRedirectUri)
+        {
+            return (await QueryAsync(client => client.PostLogoutRedirectUris.Any(value => value.Value == postLogoutRedirectUri))).ToList();
         }
 
         public Task<ListResponse<OAuthClientApplicationSummary>> GetOAuthClientApplicationsAsync(string orgId, ListRequest listRequest)

--- a/src/LagoVista.UserAdmin/Interfaces/Managers/IOAuthClientApplicationManager.cs
+++ b/src/LagoVista.UserAdmin/Interfaces/Managers/IOAuthClientApplicationManager.cs
@@ -2,6 +2,7 @@ using LagoVista.Core.Models;
 using LagoVista.Core.Models.UIMetaData;
 using LagoVista.Core.Validation;
 using LagoVista.UserAdmin.Models.Auth;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace LagoVista.UserAdmin.Interfaces.Managers
@@ -13,6 +14,7 @@ namespace LagoVista.UserAdmin.Interfaces.Managers
         Task<InvokeResult> DeleteOAuthClientApplicationAsync(string id, EntityHeader org, EntityHeader user);
         Task<OAuthClientApplication> GetOAuthClientApplicationAsync(string id, EntityHeader org, EntityHeader user);
         Task<OAuthClientApplication> GetOAuthClientApplicationByClientIdAsync(string clientId);
+        Task<List<OAuthClientApplication>> GetOAuthClientApplicationsByPostLogoutRedirectUriAsync(string postLogoutRedirectUri);
         Task<ListResponse<OAuthClientApplicationSummary>> GetOAuthClientApplicationsForOrgAsync(EntityHeader org, EntityHeader user, ListRequest listRequest);
         Task<bool> QueryKeyInUseAsync(string key, EntityHeader org);
         Task<bool> QueryClientIdInUseAsync(string clientId, string currentId = null);

--- a/src/LagoVista.UserAdmin/Interfaces/Repos/Security/IOAuthClientApplicationRepo.cs
+++ b/src/LagoVista.UserAdmin/Interfaces/Repos/Security/IOAuthClientApplicationRepo.cs
@@ -1,5 +1,6 @@
 using LagoVista.Core.Models.UIMetaData;
 using LagoVista.UserAdmin.Models.Auth;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace LagoVista.UserAdmin.Interfaces.Repos.Security
@@ -11,6 +12,7 @@ namespace LagoVista.UserAdmin.Interfaces.Repos.Security
         Task DeleteOAuthClientApplicationAsync(string id);
         Task<OAuthClientApplication> GetOAuthClientApplicationAsync(string id);
         Task<OAuthClientApplication> GetOAuthClientApplicationByClientIdAsync(string clientId);
+        Task<List<OAuthClientApplication>> GetOAuthClientApplicationsByPostLogoutRedirectUriAsync(string postLogoutRedirectUri);
         Task<ListResponse<OAuthClientApplicationSummary>> GetOAuthClientApplicationsAsync(string orgId, ListRequest listRequest);
         Task<bool> QueryKeyInUseAsync(string key, string orgId);
         Task<bool> QueryClientIdInUseAsync(string clientId, string currentId = null);

--- a/src/LagoVista.UserAdmin/Managers/OAuthClientApplicationManager.cs
+++ b/src/LagoVista.UserAdmin/Managers/OAuthClientApplicationManager.cs
@@ -8,6 +8,7 @@ using LagoVista.UserAdmin.Interfaces.Managers;
 using LagoVista.UserAdmin.Interfaces.Repos.Security;
 using LagoVista.UserAdmin.Models.Auth;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using static LagoVista.Core.Models.AuthorizeResult;
 
@@ -112,6 +113,14 @@ namespace LagoVista.UserAdmin.Managers
             if (client != null)
                 client.ClientSecret = null;
             return client;
+        }
+
+        public async Task<List<OAuthClientApplication>> GetOAuthClientApplicationsByPostLogoutRedirectUriAsync(string postLogoutRedirectUri)
+        {
+            var clients = await _repo.GetOAuthClientApplicationsByPostLogoutRedirectUriAsync(postLogoutRedirectUri);
+            foreach (var client in clients)
+                client.ClientSecret = null;
+            return clients;
         }
 
         public async Task<ListResponse<OAuthClientApplicationSummary>> GetOAuthClientApplicationsForOrgAsync(EntityHeader org, EntityHeader user, ListRequest listRequest)


### PR DESCRIPTION
## Summary
- advertise `/connect/logout` as the OIDC end-session endpoint
- enable OpenIddict end-session passthrough
- clear the NuvIoT browser authentication session without revoking issued tokens
- grant authorization-code clients end-session endpoint permission
- validate `post_logout_redirect_uri` through the existing registered client metadata
- add UserAdmin-backed lookup by post-logout redirect URI for OpenIddict

## Scope
This intentionally implements RP-initiated logout only. Token revocation and broader account/device cleanup remain separate concerns.

## Verification
OpenIddict 7.6 documentation confirms `SetEndSessionEndpointUris`, `EnableEndSessionEndpointPassthrough`, and `Permissions.Endpoints.EndSession` are the intended server APIs. A local compile attempt was blocked because the execution environment could not resolve github.com, so CI/runtime verification is still required.